### PR TITLE
ensure alpha-circulant only in Jacobian for quasi-Newton iterations

### DIFF
--- a/asQ/paradiag.py
+++ b/asQ/paradiag.py
@@ -85,6 +85,10 @@ class JacobianMatrix(object):
                     tensor=self.F_prev)
         self.F += self.F_prev
 
+        # unset flag if alpha-circulant approximation only in Jacobian
+        if self.paradiag.circ not in ["picard"]:
+            self.paradiag.Circ.assign(0.0)
+
         # Apply boundary conditions
         # assumes paradiag.w_all contains the current state we are
         # interested in


### PR DESCRIPTION
The alpha circulant option in the non-linear residual is set before applying the Jacobian matrix if the picard or quasi-Newton methods are used.
This PR makes sure that this option is unset again if the alpha circulant approximation is only meant to be used in the Jacobian (quasi-Newton method).