### PR TITLE
Time average fix

### DIFF
--- a/asQ/diag_preconditioner.py
+++ b/asQ/diag_preconditioner.py
@@ -49,6 +49,8 @@ class DiagFFTPC(object):
         aaos = paradiag.aaos
         self.aaos = paradiag.aaos
 
+        paradiag.diagfftpc = self
+
         # option for whether to use slice or window average for block jacobian
         self.jac_average = PETSc.Options().getString(
             f"{prefix}{self.prefix}jac_average", default='window')
@@ -314,14 +316,32 @@ class DiagFFTPC(object):
                 self.CblockV_bcs.append(all_bc)
 
     @PETSc.Log.EventDecorator()
-    def update(self, pc):
+    def time_average(self, uaverage):
+        # accumulate over local time-slice
+        uaverage.assign(0)
+        us = uaverage.split()
+
+        for step in range(self.aaos.nlocal_timesteps):
+            for cpt in range(self.aaos.ncomponents):
+                us[cpt].assign(us[cpt] + self.aaos.get_component(step, cpt))
+
+        # average only over current time-slice
+        if self.jac_average == 'slice':
+            uaverage /= self.aaos.nlocal_timesteps
+        else:  # implies self.jac_average == 'window':
+            uaverage /= sum(self.time_partition)
+
+        # average only over current time-slice
+        if self.jac_average == 'window':
+            self.ensemble.allreduce(uaverage, self.ubuf)
+            uaverage.assign(self.ubuf)
+
+    @PETSc.Log.EventDecorator()
+    def update_old(self, pc):
         '''
-        we need to update u0 from w_all, containing state.
-        we copy w_all into the "real" and "imaginary" parts of u0
-        this is so that when we linearise the nonlinearity, we get
-        an operator that is block diagonal in the 2x2 system coupling
-        real and imaginary parts.
+        Original update method
         '''
+
         self.u0.assign(0)
         for i in range(self.aaos.nlocal_timesteps):
             # copy the data into solver input
@@ -343,6 +363,64 @@ class DiagFFTPC(object):
             self.paradiag.ensemble.allreduce(self.u0, self.ureduceC)
             self.u0.assign(self.ureduceC)
             self.u0 /= sum(self.time_partition)
+
+    @PETSc.Log.EventDecorator()
+    def update_new(self, pc):
+        '''
+        What the update method should be
+        '''
+        self.time_average(self.ureduce)
+
+        # copy the data into solver input
+        u0s = self.u0.split()
+        urs = self.ureduce.split()
+        for r in range(2):
+            for cpt in range(self.aaos.ncomponents):
+                u0s[cpt].sub(r).assign(urs[cpt])
+
+    @PETSc.Log.EventDecorator()
+    def update(self, pc, old=True):
+        '''
+        we need to update u0 from w_all, containing state.
+        we copy w_all into the "real" and "imaginary" parts of u0
+        this is so that when we linearise the nonlinearity, we get
+        an operator that is block diagonal in the 2x2 system coupling
+        real and imaginary parts.
+        '''
+
+        if old:
+            self.update_old(pc)
+            return
+
+        # accumulate over local time-slice
+        self.ureduce.assign(0)
+        urs = self.ureduce.split()
+
+        for step in range(self.aaos.nlocal_timesteps):
+            for cpt in range(self.aaos.ncomponents):
+                urs[cpt].assign(urs[cpt] + self.aaos.get_component(step, cpt))
+
+        # average over time-slice or window
+        if self.jac_average == 'slice':
+            self.ureduce /= self.aaos.nlocal_timesteps
+        else:  # implies self.jac_average == 'window':
+            self.ureduce /= sum(self.time_partition)
+
+        # # reduce real valued function then assign real function into complex function
+        # if self.jac_average == 'window':
+        #     self.ensemble.allreduce(self.ureduce, self.ubuf)
+        #     self.ureduce.assign(self.ubuf)
+
+        # copy the real function into complex function
+        u0s = self.u0.split()
+        for r in range(2):
+            for cpt in range(self.ncpts):
+                u0s[cpt].sub(r).assign(urs[cpt])
+
+        # assign real function into complex function then reduce complex function
+        if self.jac_average == 'window':
+            self.ensemble.allreduce(self.u0, self.ureduceC)
+            self.u0.assign(self.ureduceC)
 
     @PETSc.Log.EventDecorator()
     def apply(self, pc, x, y):

--- a/tests/test_paradiag.py
+++ b/tests/test_paradiag.py
@@ -928,7 +928,9 @@ def test_solve_para_form_mixed():
 
 
 @pytest.mark.parallel(nprocs=6)
-def test_time_average():
+@pytest.mark.parametrize("ncpts", [1, 2, 3])
+@pytest.mark.parametrize("variation", ["uniform", "linear"])
+def test_time_average_mixed(ncpts, variation):
     '''
     Checks that the DiagFFTPC properly calculates the time-averaged solution
     '''
@@ -938,129 +940,7 @@ def test_time_average():
     ensemble = fd.Ensemble(fd.COMM_WORLD, nspatial_domains)
     mesh = fd.UnitSquareMesh(4, 4, comm=ensemble.comm)
     V = fd.FunctionSpace(mesh, "CG", 1)
-
-    x, y = fd.SpatialCoordinate(mesh)
-    u0 = fd.Function(V).interpolate(fd.exp(-((x-0.5)**2 + (y-0.5)**2)/0.5**2))
-    dt = 0.01
-    theta = 0.5
-    alpha = 0.001
-    c = fd.Constant(1)
-    M = [2, 2, 2]
-    nt = np.sum(M)
-
-    # Parameters for the diag
-    sparameters = {
-        "ksp_type": "preonly",
-        'pc_type': 'lu',
-        'pc_factor_mat_solver_type': 'mumps'
-    }
-
-    solver_parameters_diag = {
-        "snes_linesearch_type": "basic",
-        'snes_monitor': None,
-        'snes_stol': 1.0e-100,
-        'snes_converged_reason': None,
-        'mat_type': 'matfree',
-        'ksp_type': 'gmres',
-        'ksp_monitor': None,
-        'pc_type': 'python',
-        'pc_python_type': 'asQ.DiagFFTPC'}
-
-    for i in range(np.sum(M)):
-        solver_parameters_diag["diagfft_" + str(i) + "_"] = sparameters
-
-    def form_function(u, v):
-        return fd.inner((1.+c*fd.inner(u, u))*fd.grad(u), fd.grad(v))*fd.dx
-
-    def form_mass(u, v):
-        return u*v*fd.dx
-
-    PD = asQ.paradiag(ensemble=ensemble,
-                      form_function=form_function,
-                      form_mass=form_mass, w0=u0,
-                      dt=dt, theta=theta,
-                      alpha=alpha,
-                      time_partition=M,
-                      solver_parameters=solver_parameters_diag,
-                      circ="quasi", tol=1.0e-6, maxits=None,
-                      ctx={}, block_mat_type="aij")
-
-    # need to call solve at least once to make sure PC is initialised by snes
-    PD.solve()
-
-    # pc = PD.snes.getKSP().getPC()
-    pc = PD.diagfftpc
-
-    uaverage = fd.Function(V).assign(0)
-    ucheck = fd.Function(V).assign(0)
-
-    ucomplex0 = fd.Function(pc.CblockV)
-    ucomplex1 = fd.Function(pc.CblockV)
-
-    aaos = PD.aaos
-
-    for sstep in range(aaos.nlocal_timesteps):
-        wstep = aaos.shift_index(sstep, from_range='slice', to_range='window')
-        u0.assign(wstep)
-        aaos.set_timestep(sstep, u0)
-
-    ucheck.assign(0.5*(nt-1))
-
-    pc.time_average(uaverage)
-
-    assert fd.errornorm(uaverage, ucheck) < 1e-12
-
-    u0s = pc.u0.split()
-    ucs = ucheck.split()
-
-    pc.update(pc, old=True)
-    ucomplex0.assign(pc.u0)
-
-    pc.update(pc, old=False)
-    ucomplex1.assign(pc.u0)
-
-    assert fd.errornorm(ucomplex0, ucomplex1) < 1e-12
-
-    for r in range(2):
-        for cpt in range(aaos.ncomponents):
-            assert fd.errornorm(u0s[cpt].sub(r), ucs[cpt])
-
-    u0.assign(1)
-    for sstep in range(aaos.nlocal_timesteps):
-        wstep = aaos.shift_index(sstep, from_range='slice', to_range='window')
-        aaos.set_timestep(sstep, u0)
-
-    ucheck.assign(1)
-
-    pc.time_average(uaverage)
-
-    assert fd.errornorm(uaverage, ucheck) < 1e-12
-
-    pc.update(pc, old=True)
-    ucomplex0.assign(pc.u0)
-
-    pc.update(pc, old=False)
-    ucomplex1.assign(pc.u0)
-
-    assert fd.errornorm(ucomplex0, ucomplex1) < 1e-12
-
-    for r in range(2):
-        for cpt in range(aaos.ncomponents):
-            assert fd.errornorm(u0s[cpt].sub(r), ucs[cpt])
-
-
-@pytest.mark.parallel(nprocs=6)
-def test_time_average_mixed():
-    '''
-    Checks that the DiagFFTPC properly calculates the time-averaged solution
-    '''
-
-    # set up the ensemble communicator for space-time parallelism
-    nspatial_domains = 2
-    ensemble = fd.Ensemble(fd.COMM_WORLD, nspatial_domains)
-    mesh = fd.UnitSquareMesh(4, 4, comm=ensemble.comm)
-    V = fd.FunctionSpace(mesh, "CG", 1)
-    V = V*V
+    W = reduce(mul, (V for _ in range(ncpts)))
 
     def assign(u, expr):
         for v in u.split():
@@ -1072,14 +952,14 @@ def test_time_average_mixed():
 
     x, y = fd.SpatialCoordinate(mesh)
     init_expr = fd.exp(-((x-0.5)**2 + (y-0.5)**2)/0.5**2)
-    u0 = fd.Function(V)
+    u0 = fd.Function(W)
     interp(u0, init_expr)
     dt = 0.01
     theta = 0.5
     alpha = 0.001
     c = fd.Constant(1)
     M = [2, 2, 2]
-    nt = np.sum(M)
+    nt = sum(M)
 
     # Parameters for the diag
     sparameters = {
@@ -1099,15 +979,20 @@ def test_time_average_mixed():
         'pc_type': 'python',
         'pc_python_type': 'asQ.DiagFFTPC'}
 
-    for i in range(np.sum(M)):
+    for i in range(sum(M)):
         solver_parameters_diag["diagfft_" + str(i) + "_"] = sparameters
 
-    def form_function(u, p, v, q):
-        return (fd.inner((1.+c*fd.inner(u, u))*fd.grad(u), fd.grad(v))
-                + fd.inner((1.+c*fd.inner(p, p))*fd.grad(p), fd.grad(q)))*fd.dx
+    def form_f(u, v):
+        return fd.inner((1.+c*fd.inner(u, u))*fd.grad(u), fd.grad(v))*fd.dx
 
-    def form_mass(u, p, v, q):
-        return (u*v + p*q)*fd.dx
+    def form_m(u, v):
+        return u*v*fd.dx
+
+    def form_function(*args):
+        return sum((form_f(args[i], args[ncpts+i]) for i in range(ncpts)))
+
+    def form_mass(*args):
+        return sum((form_m(args[i], args[ncpts+i]) for i in range(ncpts)))
 
     PD = asQ.paradiag(ensemble=ensemble,
                       form_function=form_function,
@@ -1124,8 +1009,8 @@ def test_time_average_mixed():
 
     pc = PD.diagfftpc
 
-    uaverage = fd.Function(V)
-    ucheck = fd.Function(V)
+    uaverage = fd.Function(W)
+    ucheck = fd.Function(W)
 
     assign(uaverage, 0)
     assign(ucheck, 0)
@@ -1135,13 +1020,23 @@ def test_time_average_mixed():
 
     aaos = PD.aaos
 
+    if variation == "uniform":
+        assign(ucheck, 1)
+
+        def set_field(u, w):
+            assign(u, 1)
+
+    elif variation == "linear":
+        assign(ucheck, 0.5*(nt-1))
+
+        def set_field(u, w):
+            assign(u, w)
+
     # arithmetic sequence
     for sstep in range(aaos.nlocal_timesteps):
         wstep = aaos.shift_index(sstep, from_range='slice', to_range='window')
-        assign(u0, wstep)
-        aaos.set_timestep(sstep, u0)
-
-    assign(ucheck, 0.5*(nt-1))
+        set_field(u0, wstep)
+        aaos.set_field(sstep, u0)
 
     # time average works
     pc.time_average(uaverage)
@@ -1152,32 +1047,7 @@ def test_time_average_mixed():
     ucs = ucheck.split()
 
     # new update gives same result as old update
-    pc.update(pc, old=True)
-    ucomplex0.assign(pc.u0)
-
-    pc.update(pc, old=False)
-    ucomplex1.assign(pc.u0)
-
-    assert fd.errornorm(ucomplex0, ucomplex1) < 1e-12
-
-    # both components of complex average match the real average
-    for r in range(2):
-        for cpt in range(aaos.ncomponents):
-            assert fd.errornorm(u0s[cpt].sub(r), ucs[cpt])
-
-    u0.assign(1)
-    for step in range(aaos.nlocal_timesteps):
-        aaos.set_timestep(step, u0)
-
-    # uniform field sequence
-    assign(ucheck, 1)
-
-    # time average works
-    pc.time_average(uaverage)
-
-    assert fd.errornorm(uaverage, ucheck) < 1e-12
-
-    # new update gives same result as old update
+    # TO BE REMOVED AFTER BUGFIX
     pc.update(pc, old=True)
     ucomplex0.assign(pc.u0)
 

--- a/tests/test_paradiag.py
+++ b/tests/test_paradiag.py
@@ -925,3 +925,268 @@ def test_solve_para_form_mixed():
         ind2 = 2*left + 2*i + 1
         assert (fd.errornorm(vfull_list[ind1], PD.aaos.w_all.sub(2*i)) < 1.0e-9)
         assert (fd.errornorm(vfull_list[ind2], PD.aaos.w_all.sub(2*i+1)) < 1.0e-9)
+
+
+@pytest.mark.parallel(nprocs=6)
+def test_time_average():
+    '''
+    Checks that the DiagFFTPC properly calculates the time-averaged solution
+    '''
+
+    # set up the ensemble communicator for space-time parallelism
+    nspatial_domains = 2
+    ensemble = fd.Ensemble(fd.COMM_WORLD, nspatial_domains)
+    mesh = fd.UnitSquareMesh(4, 4, comm=ensemble.comm)
+    V = fd.FunctionSpace(mesh, "CG", 1)
+
+    x, y = fd.SpatialCoordinate(mesh)
+    u0 = fd.Function(V).interpolate(fd.exp(-((x-0.5)**2 + (y-0.5)**2)/0.5**2))
+    dt = 0.01
+    theta = 0.5
+    alpha = 0.001
+    c = fd.Constant(1)
+    M = [2, 2, 2]
+    nt = np.sum(M)
+
+    # Parameters for the diag
+    sparameters = {
+        "ksp_type": "preonly",
+        'pc_type': 'lu',
+        'pc_factor_mat_solver_type': 'mumps'
+    }
+
+    solver_parameters_diag = {
+        "snes_linesearch_type": "basic",
+        'snes_monitor': None,
+        'snes_stol': 1.0e-100,
+        'snes_converged_reason': None,
+        'mat_type': 'matfree',
+        'ksp_type': 'gmres',
+        'ksp_monitor': None,
+        'pc_type': 'python',
+        'pc_python_type': 'asQ.DiagFFTPC'}
+
+    for i in range(np.sum(M)):
+        solver_parameters_diag["diagfft_" + str(i) + "_"] = sparameters
+
+    def form_function(u, v):
+        return fd.inner((1.+c*fd.inner(u, u))*fd.grad(u), fd.grad(v))*fd.dx
+
+    def form_mass(u, v):
+        return u*v*fd.dx
+
+    PD = asQ.paradiag(ensemble=ensemble,
+                      form_function=form_function,
+                      form_mass=form_mass, w0=u0,
+                      dt=dt, theta=theta,
+                      alpha=alpha,
+                      time_partition=M,
+                      solver_parameters=solver_parameters_diag,
+                      circ="quasi", tol=1.0e-6, maxits=None,
+                      ctx={}, block_mat_type="aij")
+
+    # need to call solve at least once to make sure PC is initialised by snes
+    PD.solve()
+
+    # pc = PD.snes.getKSP().getPC()
+    pc = PD.diagfftpc
+
+    uaverage = fd.Function(V).assign(0)
+    ucheck = fd.Function(V).assign(0)
+
+    ucomplex0 = fd.Function(pc.CblockV)
+    ucomplex1 = fd.Function(pc.CblockV)
+
+    aaos = PD.aaos
+
+    for sstep in range(aaos.nlocal_timesteps):
+        wstep = aaos.shift_index(sstep, from_range='slice', to_range='window')
+        u0.assign(wstep)
+        aaos.set_timestep(sstep, u0)
+
+    ucheck.assign(0.5*(nt-1))
+
+    pc.time_average(uaverage)
+
+    assert fd.errornorm(uaverage, ucheck) < 1e-12
+
+    u0s = pc.u0.split()
+    ucs = ucheck.split()
+
+    pc.update(pc, old=True)
+    ucomplex0.assign(pc.u0)
+
+    pc.update(pc, old=False)
+    ucomplex1.assign(pc.u0)
+
+    assert fd.errornorm(ucomplex0, ucomplex1) < 1e-12
+
+    for r in range(2):
+        for cpt in range(aaos.ncomponents):
+            assert fd.errornorm(u0s[cpt].sub(r), ucs[cpt])
+
+    u0.assign(1)
+    for sstep in range(aaos.nlocal_timesteps):
+        wstep = aaos.shift_index(sstep, from_range='slice', to_range='window')
+        aaos.set_timestep(sstep, u0)
+
+    ucheck.assign(1)
+
+    pc.time_average(uaverage)
+
+    assert fd.errornorm(uaverage, ucheck) < 1e-12
+
+    pc.update(pc, old=True)
+    ucomplex0.assign(pc.u0)
+
+    pc.update(pc, old=False)
+    ucomplex1.assign(pc.u0)
+
+    assert fd.errornorm(ucomplex0, ucomplex1) < 1e-12
+
+    for r in range(2):
+        for cpt in range(aaos.ncomponents):
+            assert fd.errornorm(u0s[cpt].sub(r), ucs[cpt])
+
+
+@pytest.mark.parallel(nprocs=6)
+def test_time_average_mixed():
+    '''
+    Checks that the DiagFFTPC properly calculates the time-averaged solution
+    '''
+
+    # set up the ensemble communicator for space-time parallelism
+    nspatial_domains = 2
+    ensemble = fd.Ensemble(fd.COMM_WORLD, nspatial_domains)
+    mesh = fd.UnitSquareMesh(4, 4, comm=ensemble.comm)
+    V = fd.FunctionSpace(mesh, "CG", 1)
+    V = V*V
+
+    def assign(u, expr):
+        for v in u.split():
+            v.assign(expr)
+
+    def interp(u, expr):
+        for v in u.split():
+            v.interpolate(expr)
+
+    x, y = fd.SpatialCoordinate(mesh)
+    init_expr = fd.exp(-((x-0.5)**2 + (y-0.5)**2)/0.5**2)
+    u0 = fd.Function(V)
+    interp(u0, init_expr)
+    dt = 0.01
+    theta = 0.5
+    alpha = 0.001
+    c = fd.Constant(1)
+    M = [2, 2, 2]
+    nt = np.sum(M)
+
+    # Parameters for the diag
+    sparameters = {
+        "ksp_type": "preonly",
+        'pc_type': 'lu',
+        'pc_factor_mat_solver_type': 'mumps'
+    }
+
+    solver_parameters_diag = {
+        "snes_linesearch_type": "basic",
+        'snes_monitor': None,
+        'snes_stol': 1.0e-100,
+        'snes_converged_reason': None,
+        'mat_type': 'matfree',
+        'ksp_type': 'gmres',
+        'ksp_monitor': None,
+        'pc_type': 'python',
+        'pc_python_type': 'asQ.DiagFFTPC'}
+
+    for i in range(np.sum(M)):
+        solver_parameters_diag["diagfft_" + str(i) + "_"] = sparameters
+
+    def form_function(u, p, v, q):
+        return (fd.inner((1.+c*fd.inner(u, u))*fd.grad(u), fd.grad(v))
+                + fd.inner((1.+c*fd.inner(p, p))*fd.grad(p), fd.grad(q)))*fd.dx
+
+    def form_mass(u, p, v, q):
+        return (u*v + p*q)*fd.dx
+
+    PD = asQ.paradiag(ensemble=ensemble,
+                      form_function=form_function,
+                      form_mass=form_mass, w0=u0,
+                      dt=dt, theta=theta,
+                      alpha=alpha,
+                      time_partition=M,
+                      solver_parameters=solver_parameters_diag,
+                      circ="quasi", tol=1.0e-6, maxits=None,
+                      ctx={}, block_mat_type="aij")
+
+    # need to call solve at least once to make sure PC is initialised by snes
+    PD.solve()
+
+    pc = PD.diagfftpc
+
+    uaverage = fd.Function(V)
+    ucheck = fd.Function(V)
+
+    assign(uaverage, 0)
+    assign(ucheck, 0)
+
+    ucomplex0 = fd.Function(pc.CblockV)
+    ucomplex1 = fd.Function(pc.CblockV)
+
+    aaos = PD.aaos
+
+    # arithmetic sequence
+    for sstep in range(aaos.nlocal_timesteps):
+        wstep = aaos.shift_index(sstep, from_range='slice', to_range='window')
+        assign(u0, wstep)
+        aaos.set_timestep(sstep, u0)
+
+    assign(ucheck, 0.5*(nt-1))
+
+    # time average works
+    pc.time_average(uaverage)
+
+    assert fd.errornorm(uaverage, ucheck) < 1e-12
+
+    u0s = pc.u0.split()
+    ucs = ucheck.split()
+
+    # new update gives same result as old update
+    pc.update(pc, old=True)
+    ucomplex0.assign(pc.u0)
+
+    pc.update(pc, old=False)
+    ucomplex1.assign(pc.u0)
+
+    assert fd.errornorm(ucomplex0, ucomplex1) < 1e-12
+
+    # both components of complex average match the real average
+    for r in range(2):
+        for cpt in range(aaos.ncomponents):
+            assert fd.errornorm(u0s[cpt].sub(r), ucs[cpt])
+
+    u0.assign(1)
+    for step in range(aaos.nlocal_timesteps):
+        aaos.set_timestep(step, u0)
+
+    # uniform field sequence
+    assign(ucheck, 1)
+
+    # time average works
+    pc.time_average(uaverage)
+
+    assert fd.errornorm(uaverage, ucheck) < 1e-12
+
+    # new update gives same result as old update
+    pc.update(pc, old=True)
+    ucomplex0.assign(pc.u0)
+
+    pc.update(pc, old=False)
+    ucomplex1.assign(pc.u0)
+
+    assert fd.errornorm(ucomplex0, ucomplex1) < 1e-12
+
+    # both components of complex average match the real average
+    for r in range(2):
+        for cpt in range(aaos.ncomponents):
+            assert fd.errornorm(u0s[cpt].sub(r), ucs[cpt])


### PR DESCRIPTION
This pull request will change the `DiagFFTPC.update()` method to do the time average on a real-valued function instead of a (twice as large) complex function.
The first implementation of this in the `all_at_once_system` branch was broken, this branch will fix it.