### PR TITLE
Component indexing

### DIFF
--- a/asQ/allatoncesystem.py
+++ b/asQ/allatoncesystem.py
@@ -149,7 +149,10 @@ class AllAtOnceSystem(object):
 
     def set_boundary_conditions(self, bcs):
         """
-        Set the boundary conditions onto each solution in the all-at-once system
+        Set the boundary conditions onto solution at each timestep in the all-at-once system.
+        Returns a list of all boundary conditions on the all-at-once system.
+
+        :arg bcs: a list of the boundary conditions to apply
         """
         is_mixed_element = isinstance(self.function_space.ufl_element(), fd.MixedElement)
 
@@ -157,10 +160,10 @@ class AllAtOnceSystem(object):
         for bc in bcs:
             for step in range(self.nlocal_timesteps):
                 if is_mixed_element:
-                    i = bc.function_space().index
-                    index = step*self.ncomponents + i
+                    cpt = bc.function_space().index
                 else:
-                    index = step
+                    cpt = 0
+                index = self.shift_index(step, cpt)
                 bc_all = fd.DirichletBC(self.function_space_all.sub(index),
                                         bc.function_arg,
                                         bc.sub_domain)
@@ -186,15 +189,19 @@ class AllAtOnceSystem(object):
         if not (minidx <= i < maxidx):
             raise ValueError(f"index {i} outside {index_range} range {maxidx}")
 
-    def shift_index(self, i, from_range='slice', to_range='slice'):
+    def shift_index(self, i, cpt=None, from_range='slice', to_range='slice'):
         '''
-        Shift timestep index from one range to another, and accounts for -ve indices
-        :arg i: timestep index to shift
-        :arg from_range: range of i. Either slice or window
-        :arg to_range: range to shift i to. Either slice or window
+        Shift timestep or component index from one range to another, and accounts for -ve indices.
+
+        If cpt is None, shifts from one timestep range to another. If cpt is not None, returns index in all-at-once function of component cpt in timestep i.
+
+        :arg i: timestep index to shift.
+        :arg cpt: component index in timestep i to shift.
+        :arg from_range: range of i. Either slice or window.
+        :arg to_range: range to shift i to. Either slice or window. Ignored if cpt is not None.
         '''
         if from_range == 'component' or to_range == 'component':
-            raise ValueError('Component indices cannot be shifted')
+            raise ValueError("from_range and to_range apply to the timestep index and cannot be 'component'")
 
         self.check_index(i, index_range=from_range)
 
@@ -202,21 +209,31 @@ class AllAtOnceSystem(object):
         i = i % self.max_indices[from_range]
 
         # no shift needed
-        if to_range == from_range:
-            return i
+        if (to_range == from_range):
+            if cpt is None:
+                return i
 
-        # index of first timestep in slice
-        index0 = sum(self.time_partition[:self.time_rank])
+        else:  # shift to other timestep range
 
-        if to_range == 'slice':  # 'from_range' == 'window'
-            i -= index0
+            # index of first timestep in slice
+            index0 = sum(self.time_partition[:self.time_rank])
 
-        if to_range == 'window':  # 'from_range' == 'slice'
-            i += index0
+            if to_range == 'slice':  # 'from_range' == 'window'
+                i -= index0
+
+            if to_range == 'window':  # 'from_range' == 'slice'
+                i += index0
 
         self.check_index(i, index_range=to_range)
 
-        return i
+        if cpt is None:
+            return i
+
+        else:  # cpt is not None:
+
+            self.check_index(cpt, index_range='component')
+            cpt = cpt % self.max_indices['component']
+            return i*self.ncomponents + cpt
 
     @PETSc.Log.EventDecorator()
     def set_component(self, step, cpt, wnew, index_range='slice', f_alls=None):
@@ -229,16 +246,13 @@ class AllAtOnceSystem(object):
         :arg index_range: is index in window or slice?
         :arg f_alls: an all-at-once function to set timestep in. If None, self.w_alls is used
         '''
-        step_local = self.shift_index(step, from_range=index_range, to_range='slice')
-        self.check_index(cpt, index_range='component')
+        # index of component in all at once function
+        aao_index = self.shift_index(step, cpt, from_range=index_range, to_range='slice')
 
         if f_alls is None:
             f_alls = self.w_alls
 
-        # index of first component of this step
-        index0 = self.ncomponents*step_local
-
-        f_alls[index0 + cpt].assign(wnew)
+        f_alls[aao_index].assign(wnew)
 
     @PETSc.Log.EventDecorator()
     def get_component(self, step, cpt, index_range='slice', wout=None, name=None, f_alls=None, deepcopy=False):
@@ -253,17 +267,14 @@ class AllAtOnceSystem(object):
         :arg f_alls: an all-at-once function to get timestep from. If None, self.w_alls is used
         :arg deepcopy: if True, new function is returned. If false, handle to component of f_alls is returned. Ignored if wout is not None
         '''
-        step_local = self.shift_index(step, from_range=index_range, to_range='slice')
-        self.check_index(cpt, index_range='component')
+        # index of component in all at once function
+        aao_index = self.shift_index(step, cpt, from_range=index_range, to_range='slice')
 
         if f_alls is None:
             f_alls = self.w_alls
 
-        # index of first component of this step
-        index0 = self.ncomponents*step_local
-
         # required component
-        wget = f_alls[index0 + cpt]
+        wget = f_alls[aao_index]
 
         if wout is not None:
             wout.assign(wget)

--- a/asQ/allatoncesystem.py
+++ b/asQ/allatoncesystem.py
@@ -179,7 +179,7 @@ class AllAtOnceSystem(object):
         '''
         # set valid range
         if index_range not in self.max_indices.keys():
-            raise ValueError("index_range must be one of "+" or ".join(self.max_indices.keys()))
+            raise IndexError("index_range must be one of "+" or ".join(self.max_indices.keys()))
 
         maxidx = self.max_indices[index_range]
 
@@ -187,7 +187,7 @@ class AllAtOnceSystem(object):
         minidx = -maxidx
 
         if not (minidx <= i < maxidx):
-            raise ValueError(f"index {i} outside {index_range} range {maxidx}")
+            raise IndexError(f"index {i} outside {index_range} range {maxidx}")
 
     def shift_index(self, i, cpt=None, from_range='slice', to_range='slice'):
         '''

--- a/asQ/allatoncesystem.py
+++ b/asQ/allatoncesystem.py
@@ -193,7 +193,16 @@ class AllAtOnceSystem(object):
         '''
         Shift timestep or component index from one range to another, and accounts for -ve indices.
 
+        For example, if there are 3 ensemble ranks, each owning two timesteps, then:
+            window index 0 is slice index 0 on ensemble rank 0
+            window index 1 is slice index 1 on ensemble rank 0
+            window index 2 is slice index 0 on ensemble rank 1
+            window index 3 is slice index 1 on ensemble rank 1
+            window index 4 is slice index 0 on ensemble rank 2
+            window index 5 is slice index 1 on ensemble rank 2
+
         If cpt is None, shifts from one timestep range to another. If cpt is not None, returns index in all-at-once function of component cpt in timestep i.
+        Throws IndexError if original or shifted index is out of bounds.
 
         :arg i: timestep index to shift.
         :arg cpt: None or component index in timestep i to shift.

--- a/asQ/diag_preconditioner.py
+++ b/asQ/diag_preconditioner.py
@@ -375,8 +375,8 @@ class DiagFFTPC(object):
             Jins = self.xtemp.split()
             for cpt in range(self.ncpts):
 
-                xfr_cpt = self.aaos.get_component(i, cpt, wout=Jins[cpt].sub(0), f_alls=self.xfr.split())
-                xfi_cpt = self.aaos.get_component(i, cpt, wout=Jins[cpt].sub(1), f_alls=self.xfi.split())
+                self.aaos.get_component(i, cpt, wout=Jins[cpt].sub(0), f_alls=self.xfr.split())
+                self.aaos.get_component(i, cpt, wout=Jins[cpt].sub(1), f_alls=self.xfi.split())
 
             # Do a project for Riesz map, to be superceded
             # when we get Cofunction

--- a/tests/test_allatoncesystem.py
+++ b/tests/test_allatoncesystem.py
@@ -105,11 +105,11 @@ def test_check_index(ensemble, W,
             assert False, f"{err}"
 
         # check outside +ve range
-        with pytest.raises(ValueError):
+        with pytest.raises(IndexError):
             aaos.check_index(outside_range, index_type)
 
         # check outside -ve range
-        with pytest.raises(ValueError):
+        with pytest.raises(IndexError):
             aaos.check_index(-outside_range, index_type)
 
 
@@ -173,11 +173,11 @@ def test_shift_index(ensemble, W,
     slice_index = slice_length + 1
 
     # +ve index out of slice range
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         window_index = aaos.shift_index(slice_index, from_range='slice', to_range='window')
 
     # -ve index out of slice range
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         window_index = aaos.shift_index(-slice_index, from_range='slice', to_range='window')
 
     # window_range -> slice_range
@@ -197,7 +197,7 @@ def test_shift_index(ensemble, W,
     # for some reason pytest.raises doesn't work with this call
     try:
         slice_index = aaos.shift_index(window_index, from_range='window', to_range='slice')
-    except ValueError:
+    except IndexError:
         pass
 
     # -ve index out of slice range
@@ -205,7 +205,7 @@ def test_shift_index(ensemble, W,
     # for some reason pytest.raises doesn't work with this call
     try:
         slice_index = aaos.shift_index(-window_index, from_range='window', to_range='slice')
-    except ValueError:
+    except IndexError:
         pass
 
     # component indices
@@ -225,9 +225,9 @@ def test_shift_index(ensemble, W,
     check_index = ncpts*(slice_index+1) + cpt_index
 
     # reject component index out of range
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         aaos.shift_index(0, 100, from_range='slice')
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         window_index = aaos.shift_index(0, from_range='slice', to_range='window')
         aaos.shift_index(window_index, -100, from_range='window')
 


### PR DESCRIPTION
Add in shifting component indices to `AllAtOnceSystem.shift_index`.
This means we can get the index of a particular component of a particular timestep in the all-at-once function `w_alls`