### PR TITLE
Add timeout to test runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,10 @@ jobs:
         run: |
           sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
       - uses: actions/checkout@v2
+      - name: Install test dependencies
+        run: |
+          . /home/firedrake/firedrake/bin/activate
+          python -m pip install pytest-timeout
       - name: Install
         run: |
           . /home/firedrake/firedrake/bin/activate
@@ -43,4 +47,4 @@ jobs:
         run: |
           . /home/firedrake/firedrake/bin/activate
           export OMP_NUM_THREADS=1
-          pytest -v --durations=0 tests -s
+          python -m pytest -v -s --durations=0 tests --timeout=600


### PR DESCRIPTION
Make the tests timeout if they hang so we don't end up hogging the Firedrake runners.