### PR TITLE
Allow default solver options for all diagonal blocks

### DIFF
--- a/asQ/diag_preconditioner.py
+++ b/asQ/diag_preconditioner.py
@@ -265,7 +265,12 @@ class DiagFFTPC(object):
             v = fd.TestFunction(self.CblockV)
             L = fd.inner(v, self.Jprob_in)*fd.dx
 
-            block_prefix = self.prefix+str(ii)+'_'
+            # PETSc has hard-coded limit of 512 options per manager
+            # Having different options for each block can easily reach this limit
+            # Switched to using the same options for all blocks until this is fixed in PETSc
+            # block_prefix = self.prefix+str(ii)+'_'
+            block_prefix = self.prefix+'block_'
+
             jprob = fd.LinearVariationalProblem(A, L, self.Jprob_out,
                                                 bcs=self.CblockV_bcs)
             Jsolver = fd.LinearVariationalSolver(jprob,

--- a/asQ/diag_preconditioner.py
+++ b/asQ/diag_preconditioner.py
@@ -210,7 +210,7 @@ class DiagFFTPC(object):
         v = fd.TestFunction(self.CblockV)
         u = fd.TrialFunction(self.CblockV)
         a = fd.assemble(fd.inner(u, v)*fd.dx)
-        self.Proj = fd.LinearSolver(a, options_prefix=self.prefix+"mass_")
+        self.Proj = fd.LinearSolver(a, options_prefix=f"{prefix}{self.prefix}mass_")
 
         # building the Jacobian of the nonlinear term
         # what we want is a block diagonal matrix in the 2x2 system
@@ -265,11 +265,15 @@ class DiagFFTPC(object):
             v = fd.TestFunction(self.CblockV)
             L = fd.inner(v, self.Jprob_in)*fd.dx
 
-            # PETSc has hard-coded limit of 512 options per manager
-            # Having different options for each block can easily reach this limit
-            # Switched to using the same options for all blocks until this is fixed in PETSc
-            # block_prefix = self.prefix+str(ii)+'_'
-            block_prefix = self.prefix+'block_'
+            # Options with prefix 'diagfft_block_' apply to all blocks by default
+            # If any options with prefix 'diagfft_block_{i}' exist, where i is the
+            # block number, then this prefix is used instead (like pc fieldsplit)
+
+            block_prefix = f"{prefix}{self.prefix}block_"
+            for k, v in PETSc.Options().getAll().items():
+                if k.startswith(f"{block_prefix}{str(ii)}_"):
+                    block_prefix = f"{block_prefix}{str(ii)}_"
+                    break
 
             jprob = fd.LinearVariationalProblem(A, L, self.Jprob_out,
                                                 bcs=self.CblockV_bcs)

--- a/examples/serial/shallow_water/galewsky_comparison.py
+++ b/examples/serial/shallow_water/galewsky_comparison.py
@@ -194,8 +194,7 @@ parallel_sparameters = {
     'pc_python_type': 'asQ.DiagFFTPC'
 }
 
-for i in range(sum(time_partition)):
-    parallel_sparameters['diagfft_'+str(i)+'_'] = block_sparameters
+parallel_sparameters['diagfft_block_'] = block_sparameters
 
 block_ctx = {}
 transfer_managers = []

--- a/examples/shallow_water/galewsky.py
+++ b/examples/shallow_water/galewsky.py
@@ -67,7 +67,7 @@ sparameters = {
                 'pc_patch_save_operators': True,
                 'pc_patch_partition_of_unity': True,
                 'pc_patch_sub_mat_type': 'seqdense',
-                'pc_patch_construct_codim': 0,
+                'pc_patch_construct_dim': 0,
                 'pc_patch_construct_type': 'vanka',
                 'pc_patch_local_type': 'additive',
                 'pc_patch_precompute_element_tensors': True,
@@ -105,8 +105,7 @@ sparameters_diag = {
     'pc_python_type': 'asQ.DiagFFTPC'
 }
 
-for i in range(sum(time_partition)):
-    sparameters_diag['diagfft_'+str(i)+'_'] = sparameters
+sparameters_diag['diagfft_block_'] = sparameters
 
 create_mesh = partial(
     swe.create_mg_globe_mesh,

--- a/examples/shallow_water/williamson2.py
+++ b/examples/shallow_water/williamson2.py
@@ -141,8 +141,7 @@ sparameters_diag = {
 PETSc.Sys.Print('### === --- Calculating parallel solution --- === ###')
 PETSc.Sys.Print('')
 
-for i in range(sum(time_partition)):
-    sparameters_diag['diagfft_'+str(i)+'_'] = sparameters
+sparameters_diag['diagfft_block_'] = sparameters
 
 # non-petsc information for block solve
 block_ctx = {}

--- a/examples/shallow_water/williamson5.py
+++ b/examples/shallow_water/williamson5.py
@@ -91,8 +91,7 @@ sparameters_diag = {
     'pc_type': 'python',
     'pc_python_type': 'asQ.DiagFFTPC'}
 
-for i in range(sum(time_partition)):
-    sparameters_diag['diagfft_'+str(i)+'_'] = sparameters
+sparameters_diag['diagfft_block_'] = sparameters
 
 create_mesh = partial(
     swe.create_mg_globe_mesh,

--- a/tests/test_paradiag.py
+++ b/tests/test_paradiag.py
@@ -266,6 +266,7 @@ def test_steady_swe():
 
     M = [2, 2]
     solver_parameters_diag["diagfft_block_"] = sparameters
+    solver_parameters_diag["diagfft_block_0_"] = sparameters
 
     dt = 0.2*units.hour
 
@@ -736,7 +737,8 @@ def test_solve_para_form(bc_opt, extruded):
         'pc_type': 'python',
         'pc_python_type': 'asQ.DiagFFTPC'}
 
-    solver_parameters_diag["diagfft_block_"] = sparameters
+    for i in range(sum(M)):
+        solver_parameters_diag[f"diagfft_block_{i}_"] = sparameters
 
     def form_function(u, v):
         return fd.inner((1.+c*fd.inner(u, u))*fd.grad(u), fd.grad(v))*fd.dx

--- a/tests/test_paradiag.py
+++ b/tests/test_paradiag.py
@@ -265,8 +265,7 @@ def test_steady_swe():
         'pc_python_type': 'asQ.DiagFFTPC'}
 
     M = [2, 2]
-    for i in range(np.sum(M)):
-        solver_parameters_diag["diagfft_"+str(i)+"_"] = sparameters
+    solver_parameters_diag["diagfft_block_"] = sparameters
 
     dt = 0.2*units.hour
 
@@ -737,8 +736,7 @@ def test_solve_para_form(bc_opt, extruded):
         'pc_type': 'python',
         'pc_python_type': 'asQ.DiagFFTPC'}
 
-    for i in range(np.sum(M)):
-        solver_parameters_diag["diagfft_" + str(i) + "_"] = sparameters
+    solver_parameters_diag["diagfft_block_"] = sparameters
 
     def form_function(u, v):
         return fd.inner((1.+c*fd.inner(u, u))*fd.grad(u), fd.grad(v))*fd.dx
@@ -872,8 +870,7 @@ def test_solve_para_form_mixed(extruded):
         'pc_type': 'python',
         'pc_python_type': 'asQ.DiagFFTPC'}
 
-    for i in range(np.sum(M)):
-        solver_parameters_diag["diagfft_" + str(i) + "_"] = sparameters
+    solver_parameters_diag["diagfft_block_"] = sparameters
 
     def form_function(uu, up, vu, vp):
         return (fd.div(vu) * up + c * fd.sqrt(fd.inner(uu, uu) + eps) * fd.inner(uu, vu)


### PR DESCRIPTION
PETSc has a hard-coded limit of 512 options per options manager. Because we duplicate the block options for every block, we can quickly run into this limit if we have a large number of timesteps or a complex option set for the blocks.

This limit is being removed from PETSc by this PR: [https://gitlab.com/petsc/petsc/-/merge_requests/5838](https://gitlab.com/petsc/petsc/-/merge_requests/5838) ~~but until that is merged, and Firedrake's fork updated, we need to have each solver use the same option set.~~
We should allow for a default set of block options like `fieldsplit` does. The prefix for the default options is `diagfft_block_`. If any option exists with prefix `diagfft_block_{i}_` then block `i` will use this prefix instead.

These changes were originally in PR #90  but are split out here to keep them more self-contained.