### PR TITLE
Memory profiling

### DIFF
--- a/asQ/allatoncesystem.py
+++ b/asQ/allatoncesystem.py
@@ -3,7 +3,7 @@ from firedrake.petsc import PETSc
 from pyop2.mpi import MPI
 from functools import reduce
 from operator import mul
-from memory_profiler import profile
+from .profiling import profile
 
 
 class JacobianMatrix(object):

--- a/asQ/allatoncesystem.py
+++ b/asQ/allatoncesystem.py
@@ -14,14 +14,14 @@ class JacobianMatrix(object):
         :param aaos: The AllAtOnceSystem object
         """
         self.aaos = aaos
-        self.u = fd.Function(self.aaos.function_space_all).assign(0)  # for the input function
-        self.F = fd.Function(self.aaos.function_space_all).assign(0)  # for the output residual
-        self.F_prev = fd.Function(self.aaos.function_space_all).assign(0)  # Where we compute the
+        self.u = fd.Function(self.aaos.function_space_all)  # for the input function
+        self.F = fd.Function(self.aaos.function_space_all)  # for the output residual
+        self.F_prev = fd.Function(self.aaos.function_space_all)  # Where we compute the
         # part of the output residual from neighbouring contributions
-        self.u0 = fd.Function(self.aaos.function_space_all).assign(0)  # Where we keep the state
+        self.u0 = fd.Function(self.aaos.function_space_all)  # Where we keep the state
 
-        self.Fsingle = fd.Function(self.aaos.function_space).assign(0)
-        self.urecv = fd.Function(self.aaos.function_space).assign(0)  # will contain the previous time value i.e. 3*r-1
+        self.Fsingle = fd.Function(self.aaos.function_space)
+        self.urecv = fd.Function(self.aaos.function_space)  # will contain the previous time value i.e. 3*r-1
         self.ualls = self.u.split()
         # Jform missing contributions from the previous step
         # Find u1 s.t. F[u1, u2, u3; v] = 0 for all v
@@ -128,7 +128,7 @@ class AllAtOnceSystem(object):
         self.function_space_all = reduce(mul, (self.function_space
                                                for _ in range(self.nlocal_timesteps)))
 
-        self.w_all = fd.Function(self.function_space_all).assign(0)
+        self.w_all = fd.Function(self.function_space_all)
         self.w_alls = self.w_all.split()
 
         for i in range(self.nlocal_timesteps):
@@ -140,13 +140,13 @@ class AllAtOnceSystem(object):
             bc.apply(self.w_all)
 
         # function to assemble the nonlinear residual
-        self.F_all = fd.Function(self.function_space_all).assign(0)
+        self.F_all = fd.Function(self.function_space_all)
 
         # functions containing the last and next steps for parallel
         # communication timestep
         # from the previous iteration
-        self.w_recv = fd.Function(self.function_space).assign(0)
-        self.w_send = fd.Function(self.function_space).assign(0)
+        self.w_recv = fd.Function(self.function_space)
+        self.w_send = fd.Function(self.function_space)
 
         self._set_aao_form()
         self.jacobian = JacobianMatrix(self)
@@ -249,7 +249,6 @@ class AllAtOnceSystem(object):
             return i*self.ncomponents + cpt
 
     @PETSc.Log.EventDecorator()
-    @memprofile
     def set_component(self, step, cpt, wnew, index_range='slice', f_alls=None):
         '''
         Set component of solution at a timestep to new value
@@ -269,7 +268,6 @@ class AllAtOnceSystem(object):
         f_alls[aao_index].assign(wnew)
 
     @PETSc.Log.EventDecorator()
-    @memprofile
     def get_component(self, step, cpt, index_range='slice', wout=None, name=None, f_alls=None, deepcopy=False):
         '''
         Get component of solution at a timestep
@@ -317,7 +315,6 @@ class AllAtOnceSystem(object):
                      for cpt in range(self.ncomponents))
 
     @PETSc.Log.EventDecorator()
-    @memprofile
     def set_field(self, step, wnew, index_range='slice', f_alls=None):
         '''
         Set solution at a timestep to new value
@@ -332,7 +329,6 @@ class AllAtOnceSystem(object):
                                index_range=index_range, f_alls=f_alls)
 
     @PETSc.Log.EventDecorator()
-    @memprofile
     def get_field(self, step, index_range='slice', wout=None, name=None, f_alls=None):
         '''
         Get solution at a timestep
@@ -372,7 +368,6 @@ class AllAtOnceSystem(object):
             callback(window_index, slice_index, w)
 
     @PETSc.Log.EventDecorator()
-    @memprofile
     def next_window(self, w1=None):
         """
         Reset all-at-once-system ready for next time-window
@@ -400,7 +395,6 @@ class AllAtOnceSystem(object):
         return
 
     @PETSc.Log.EventDecorator()
-    @memprofile
     def update_time_halos(self, wsend=None, wrecv=None, walls=None, blocking=True):
         '''
         Update wrecv with the last step from the previous slice (periodic) of walls
@@ -441,7 +435,6 @@ class AllAtOnceSystem(object):
             return mpi_requests
 
     @PETSc.Log.EventDecorator()
-    @memprofile
     def update(self, X, wall=None, wsend=None, wrecv=None, blocking=True):
         '''
         Update self.w_alls and self.w_recv from PETSc Vec X.

--- a/asQ/allatoncesystem.py
+++ b/asQ/allatoncesystem.py
@@ -3,11 +3,11 @@ from firedrake.petsc import PETSc
 from pyop2.mpi import MPI
 from functools import reduce
 from operator import mul
-from .profiling import profile
+from .profiling import memprofile
 
 
 class JacobianMatrix(object):
-    @profile
+    @memprofile
     def __init__(self, aaos):
         r"""
         Python matrix for the Jacobian of the all at once system
@@ -37,8 +37,8 @@ class JacobianMatrix(object):
         self.Jform_prev = fd.derivative(self.aaos.aao_form,
                                         self.aaos.w_recv)
 
-    @profile
     @PETSc.Log.EventDecorator()
+    @memprofile
     def mult(self, mat, X, Y):
 
         self.aaos.update(X, wall=self.u, wrecv=self.urecv, blocking=True)
@@ -74,7 +74,7 @@ class JacobianMatrix(object):
 
 
 class AllAtOnceSystem(object):
-    @profile
+    @memprofile
     def __init__(self,
                  ensemble, time_partition,
                  dt, theta,
@@ -249,6 +249,7 @@ class AllAtOnceSystem(object):
             return i*self.ncomponents + cpt
 
     @PETSc.Log.EventDecorator()
+    @memprofile
     def set_component(self, step, cpt, wnew, index_range='slice', f_alls=None):
         '''
         Set component of solution at a timestep to new value
@@ -268,6 +269,7 @@ class AllAtOnceSystem(object):
         f_alls[aao_index].assign(wnew)
 
     @PETSc.Log.EventDecorator()
+    @memprofile
     def get_component(self, step, cpt, index_range='slice', wout=None, name=None, f_alls=None, deepcopy=False):
         '''
         Get component of solution at a timestep
@@ -315,6 +317,7 @@ class AllAtOnceSystem(object):
                      for cpt in range(self.ncomponents))
 
     @PETSc.Log.EventDecorator()
+    @memprofile
     def set_field(self, step, wnew, index_range='slice', f_alls=None):
         '''
         Set solution at a timestep to new value
@@ -329,6 +332,7 @@ class AllAtOnceSystem(object):
                                index_range=index_range, f_alls=f_alls)
 
     @PETSc.Log.EventDecorator()
+    @memprofile
     def get_field(self, step, index_range='slice', wout=None, name=None, f_alls=None):
         '''
         Get solution at a timestep
@@ -368,6 +372,7 @@ class AllAtOnceSystem(object):
             callback(window_index, slice_index, w)
 
     @PETSc.Log.EventDecorator()
+    @memprofile
     def next_window(self, w1=None):
         """
         Reset all-at-once-system ready for next time-window
@@ -395,6 +400,7 @@ class AllAtOnceSystem(object):
         return
 
     @PETSc.Log.EventDecorator()
+    @memprofile
     def update_time_halos(self, wsend=None, wrecv=None, walls=None, blocking=True):
         '''
         Update wrecv with the last step from the previous slice (periodic) of walls
@@ -435,6 +441,7 @@ class AllAtOnceSystem(object):
             return mpi_requests
 
     @PETSc.Log.EventDecorator()
+    @memprofile
     def update(self, X, wall=None, wsend=None, wrecv=None, blocking=True):
         '''
         Update self.w_alls and self.w_recv from PETSc Vec X.
@@ -454,8 +461,8 @@ class AllAtOnceSystem(object):
 
         return self.update_time_halos(wsend=wsend, wrecv=wrecv, walls=wall.split(), blocking=True)
 
-    @profile
     @PETSc.Log.EventDecorator()
+    @memprofile
     def _assemble_function(self, snes, X, Fvec):
         r"""
         This is the function we pass to the snes to assemble
@@ -478,7 +485,6 @@ class AllAtOnceSystem(object):
         with self.F_all.dat.vec_ro as v:
             v.copy(Fvec)
 
-    @profile
     def _set_aao_form(self):
         """
         Constructs the bilinear form for the all at once system.

--- a/asQ/diag_preconditioner.py
+++ b/asQ/diag_preconditioner.py
@@ -8,6 +8,7 @@ from operator import mul
 from functools import reduce
 import importlib
 from ufl.classes import MultiIndex, FixedIndex, Indexed
+from .profiling import profile
 
 
 class DiagFFTPC(object):

--- a/asQ/diag_preconditioner.py
+++ b/asQ/diag_preconditioner.py
@@ -8,7 +8,7 @@ from operator import mul
 from functools import reduce
 import importlib
 from ufl.classes import MultiIndex, FixedIndex, Indexed
-from .profiling import profile
+from .profiling import memprofile
 
 
 class DiagFFTPC(object):
@@ -26,7 +26,7 @@ class DiagFFTPC(object):
             self.initialize(pc)
         self.update(pc)
 
-    @profile
+    @memprofile
     def initialize(self, pc):
         if pc.getType() != "python":
             raise ValueError("Expecting PC type python")
@@ -304,6 +304,7 @@ class DiagFFTPC(object):
                 self.CblockV_bcs.append(all_bc)
 
     @PETSc.Log.EventDecorator()
+    @memprofile
     def update(self, pc):
         '''
         we need to update u0 from w_all, containing state.
@@ -334,8 +335,8 @@ class DiagFFTPC(object):
             self.u0.assign(self.ureduceC)
             self.u0 /= sum(self.time_partition)
 
-    @profile
     @PETSc.Log.EventDecorator()
+    @memprofile
     def apply(self, pc, x, y):
 
         # copy petsc vec into Function

--- a/asQ/diag_preconditioner.py
+++ b/asQ/diag_preconditioner.py
@@ -20,6 +20,7 @@ class DiagFFTPC(object):
         """
         self.initialized = False
 
+    @memprofile
     def setUp(self, pc):
         """Setup method called by PETSc."""
         if not self.initialized:
@@ -83,8 +84,8 @@ class DiagFFTPC(object):
         assert (self.blockV.dim()*partition[time_rank] == W_all.dim())
 
         # Input/Output wrapper Functions
-        self.xf = fd.Function(W_all).assign(0)  # input
-        self.yf = fd.Function(W_all).assign(0)  # output
+        self.xf = fd.Function(W_all)  # input
+        self.yf = fd.Function(W_all)  # output
 
         # Gamma coefficients
         self.Nt = np.sum(partition)
@@ -136,13 +137,13 @@ class DiagFFTPC(object):
         # Now need to build the block solver
         vs = fd.TestFunctions(self.CblockV)
         uts = fd.TrialFunctions(self.CblockV)
-        self.u0 = fd.Function(self.CblockV).assign(0)  # we will create a linearisation
+        self.u0 = fd.Function(self.CblockV)  # we will create a linearisation
         us = fd.split(self.u0)
 
         # function to do global reduction into for average block jacobian
         if self.jac_average == 'window':
-            self.ureduce = fd.Function(self.blockV).assign(0)
-            self.ureduceC = fd.Function(self.CblockV).assign(0)
+            self.ureduce = fd.Function(self.blockV)
+            self.ureduceC = fd.Function(self.CblockV)
 
         # extract the real and imaginary parts
         vsr = []
@@ -176,12 +177,12 @@ class DiagFFTPC(object):
             utsi.append(uts[1])
 
         # input and output functions
-        self.Jprob_in = fd.Function(self.CblockV).assign(0)
-        self.Jprob_out = fd.Function(self.CblockV).assign(0)
+        self.Jprob_in = fd.Function(self.CblockV)
+        self.Jprob_out = fd.Function(self.CblockV)
 
         # A place to store all the inputs to the block problems
-        self.xfi = fd.Function(W_all).assign(0)
-        self.xfr = fd.Function(W_all).assign(0)
+        self.xfi = fd.Function(W_all)
+        self.xfr = fd.Function(W_all)
 
         #  Building the nonlinear operator
         self.Jsolvers = []
@@ -207,7 +208,7 @@ class DiagFFTPC(object):
 
         # setting up the Riesz map
         # input for the Riesz map
-        self.xtemp = fd.Function(self.CblockV).assign(0)
+        self.xtemp = fd.Function(self.CblockV)
         v = fd.TestFunction(self.CblockV)
         u = fd.TrialFunction(self.CblockV)
         a = fd.assemble(fd.inner(u, v)*fd.dx)

--- a/asQ/paradiag.py
+++ b/asQ/paradiag.py
@@ -2,6 +2,7 @@ import firedrake as fd
 from firedrake.petsc import flatten_parameters
 from firedrake.petsc import PETSc, OptionsManager
 from functools import partial
+from memory_profiler import profile
 
 from asQ.allatoncesystem import AllAtOnceSystem
 
@@ -15,6 +16,7 @@ def context_callback(pc, context):
 get_context = partial(context_callback, context=appctx)
 
 
+@profile
 def create_ensemble(time_partition, comm=fd.COMM_WORLD):
     '''
     Create an Ensemble for the given slice partition
@@ -35,6 +37,7 @@ def create_ensemble(time_partition, comm=fd.COMM_WORLD):
 
 
 class paradiag(object):
+    @profile
     def __init__(self, ensemble,
                  form_function, form_mass, w0, dt, theta,
                  alpha, time_partition, bcs=[],

--- a/asQ/paradiag.py
+++ b/asQ/paradiag.py
@@ -2,7 +2,7 @@ import firedrake as fd
 from firedrake.petsc import flatten_parameters
 from firedrake.petsc import PETSc, OptionsManager
 from functools import partial
-from memory_profiler import profile
+from .profiling import profile
 
 from asQ.allatoncesystem import AllAtOnceSystem
 

--- a/asQ/paradiag.py
+++ b/asQ/paradiag.py
@@ -2,7 +2,7 @@ import firedrake as fd
 from firedrake.petsc import flatten_parameters
 from firedrake.petsc import PETSc, OptionsManager
 from functools import partial
-from .profiling import profile
+from .profiling import memprofile
 
 from asQ.allatoncesystem import AllAtOnceSystem
 
@@ -16,7 +16,6 @@ def context_callback(pc, context):
 get_context = partial(context_callback, context=appctx)
 
 
-@profile
 def create_ensemble(time_partition, comm=fd.COMM_WORLD):
     '''
     Create an Ensemble for the given slice partition
@@ -37,7 +36,7 @@ def create_ensemble(time_partition, comm=fd.COMM_WORLD):
 
 
 class paradiag(object):
-    @profile
+    @memprofile
     def __init__(self, ensemble,
                  form_function, form_mass, w0, dt, theta,
                  alpha, time_partition, bcs=[],
@@ -138,6 +137,8 @@ class paradiag(object):
         # complete the snes setup
         self.opts.set_from_options(self.snes)
 
+    @PETSc.Log.EventDecorator()
+    @memprofile
     def solve(self,
               nwindows=1,
               preproc=lambda pdg, w: None,

--- a/asQ/profiling.py
+++ b/asQ/profiling.py
@@ -9,7 +9,7 @@ if os.getenv("ASQ_PROFILE_MEM") is not None:
         from mpi4py import MPI
         from functools import partial
         rank = MPI.COMM_WORLD.rank
-        mprof_file = open(f"asq_memprof_log{rank}.txt", "w")
+        mprof_file = open(f"asq_memprof_log{rank}.dat", "w")
         memprofile = partial(profile, stream=mprof_file)
     else:
         # log memory profile to stdout

--- a/asQ/profiling.py
+++ b/asQ/profiling.py
@@ -1,10 +1,23 @@
 
 import os
 
-if os.getenv('ASQ_PROFILE') is not None:
+# profile memory use
+if os.getenv("ASQ_PROFILE_MEM") is not None:
     from memory_profiler import profile
+    if os.getenv("ASQ_PROFILE_MEM") == "file":
+        # log memory profile to file (one per MPI rank)
+        from mpi4py import MPI
+        from functools import partial
+        rank = MPI.COMM_WORLD.rank
+        mprof_file = open(f"asq_memprof_log{rank}.txt", "w")
+        memprofile = partial(profile, stream=mprof_file)
+    else:
+        # log memory profile to stdout
+        memprofile = profile
+
+# no memory profile
 else:
-    def profile(func):
+    def memprofile(func):
         def pass_through(*args, **kwargs):
             return func(*args, **kwargs)
         return pass_through

--- a/asQ/profiling.py
+++ b/asQ/profiling.py
@@ -1,7 +1,10 @@
 
-from memory_profiler import profile
+import os
 
-#def profile(func):
-#    def pass_through(*args, **kwargs):
-#        return func(*args, **kwargs)
-#    return pass_through
+if os.getenv('ASQ_PROFILE') is not None:
+    from memory_profiler import profile
+else:
+    def profile(func):
+        def pass_through(*args, **kwargs):
+            return func(*args, **kwargs)
+        return pass_through

--- a/asQ/profiling.py
+++ b/asQ/profiling.py
@@ -1,0 +1,7 @@
+
+from memory_profiler import profile
+
+#def profile(func):
+#    def pass_through(*args, **kwargs):
+#        return func(*args, **kwargs)
+#    return pass_through

--- a/examples/shallow_water/galewsky.py
+++ b/examples/shallow_water/galewsky.py
@@ -67,7 +67,7 @@ sparameters = {
                 'pc_patch_save_operators': True,
                 'pc_patch_partition_of_unity': True,
                 'pc_patch_sub_mat_type': 'seqdense',
-                'pc_patch_construct_codim': 0,
+                'pc_patch_construct_dim': 0,
                 'pc_patch_construct_type': 'vanka',
                 'pc_patch_local_type': 'additive',
                 'pc_patch_precompute_element_tensors': True,
@@ -94,6 +94,7 @@ sparameters_diag = {
         'atol': 1e-0,
         'rtol': 1e-12,
         'stol': 1e-12,
+        'max_its': 1
     },
     'mat_type': 'matfree',
     'ksp_type': 'preonly',
@@ -110,7 +111,8 @@ for i in range(sum(time_partition)):
 
 create_mesh = partial(
     swe.create_mg_globe_mesh,
-    ref_level=args.ref_level)
+    ref_level=args.ref_level,
+    coords_degree=1)
 
 PETSc.Sys.Print('### === --- Calculating parallel solution --- === ###')
 


### PR DESCRIPTION
This PR adds memory profiling using the `memory_profiler` module. The `profile` decorator has been added to various methods so that we can track the memory usage. This is enabled with the environment variable `ASQ_PROFILE_MEM`. If `ASQ_PROFILE_MEM=file` then each MPI rank writes the line-by-line memory profile to a file asq_memprof_log{rank}.dat.

These changes were originally in PR #90  but are split out here to keep them more self-contained.