### PR TITLE
add data() method to SharedArray

### DIFF
--- a/asQ/parallel_arrays.py
+++ b/asQ/parallel_arrays.py
@@ -161,6 +161,17 @@ class SharedArray(object):
         """
         self.comm.Allgatherv(MPI.IN_PLACE, [self._data, list(self.partition)])
 
+    def data(self, deepcopy=True):
+        """
+        Return numpy array of the underlying data.
+
+        :arg deepcopy: If True, a copy of the data is returned
+        """
+        if deepcopy:
+            return self._data.copy()
+        else:
+            return self._data
+
 
 class OwnedArray(object):
     def __init__(self, size, owner=0, comm=MPI.COMM_WORLD, dtype=None):

--- a/asQ/parallel_arrays.py
+++ b/asQ/parallel_arrays.py
@@ -249,3 +249,14 @@ class OwnedArray(object):
             raise ValueError("Array size must be of type int. OwnedArray only supports 1D arrays")
         self._data.resize(size, refcheck=False)
         self.size = size
+
+    def data(self, deepcopy=True):
+        """
+        Return numpy array of the underlying data.
+
+        :arg deepcopy: If True, a copy of the data is returned
+        """
+        if deepcopy:
+            return self._data.copy()
+        else:
+            return self._data

--- a/asQ/parallel_arrays.py
+++ b/asQ/parallel_arrays.py
@@ -1,5 +1,6 @@
 from pyop2.mpi import MPI
 from numpy import zeros as zero_array
+from numpy import asarray
 
 
 def in_range(i, length, allow_negative=True, throws=False):
@@ -153,13 +154,29 @@ class SharedArray(object):
             i = self.layout.transform_index(i, itype='l', rtype='g')
             self._data[i] = val
 
-    def synchronise(self):
+    def synchronise(self, root=None):
         """
         Synchronise the array over the comm.
 
         Until this method is called, array elements not owned by the current rank are not guaranteed to be valid.
+        If root=None, array is synchronised on all ranks. If root is a rank, then the array is synchronised on only that rank. Array elements on other ranks remain unsynchronised.
+
+        :arg root: The rank to synchronise the array onto. None for synchronise on all ranks.
         """
-        self.comm.Allgatherv(MPI.IN_PLACE, [self._data, list(self.partition)])
+        if root is None:
+            sendbuf = MPI.IN_PLACE
+            recvbuf = [self._data, list(self.partition)]
+            self.comm.Allgatherv(sendbuf, recvbuf)
+        else:
+            if self.rank == root:
+                sendbuf = MPI.IN_PLACE
+                recvbuf = [self._data, list(self.partition)]
+            else:
+                begin = self.offset
+                end = begin + self.local_size
+                sendbuf = asarray(self._data[begin:end])
+                recvbuf = None
+            self.comm.Gatherv(sendbuf, recvbuf, root=root)
 
     def data(self, deepcopy=True):
         """

--- a/tests/test_parallel_arrays.py
+++ b/tests/test_parallel_arrays.py
@@ -189,6 +189,7 @@ def test_shared_array(partition):
             j = offset + i
             assert array.dglobal[j] == check
 
+    # test copying data
     copy = array.data()
     assert copy is not array._data
 
@@ -304,3 +305,13 @@ def test_owned_array():
     # check new data
     for i in range(new_size):
         assert array[i] == 10*(i-5)
+
+    # test copying data
+    copy = array.data()
+    assert copy is not array._data
+
+    for i in range(array.size):
+        assert copy[i] == array[i]
+
+    dat = array.data(deepcopy=False)
+    assert dat is array._data

--- a/tests/test_parallel_arrays.py
+++ b/tests/test_parallel_arrays.py
@@ -2,6 +2,7 @@ import pytest
 from pyop2.mpi import MPI
 from asQ.parallel_arrays import in_range
 from asQ import DistributedDataLayout1D, SharedArray, OwnedArray
+from numpy import allclose
 
 partitions = [3, (2, 3, 4, 2)]
 
@@ -196,6 +197,25 @@ def test_shared_array(partition):
 
     dat = array.data(deepcopy=False)
     assert dat is array._data
+
+    # test synchronise to one rank
+    for i in range(local_size):
+        array.dlocal[i] = array.rank + 1
+
+    root = 1
+    before = array.data()
+    array.synchronise(root=root)
+    after = array.data()
+
+    if array.rank == root:
+        for rank in range(array.comm.size):
+            check = rank + 1
+            offset = sum(partition[:rank])
+            for i in range(partition[rank]):
+                j = offset + i
+                assert array.dglobal[j] == check
+    else:
+        assert allclose(before, after)
 
 
 @pytest.mark.parallel(nprocs=4)

--- a/tests/test_parallel_arrays.py
+++ b/tests/test_parallel_arrays.py
@@ -188,6 +188,15 @@ def test_shared_array(partition):
             j = offset + i
             assert array.dglobal[j] == check
 
+    copy = array.data()
+    assert copy is not array._data
+
+    for i in range(array.global_size):
+        assert copy[i] == array.dglobal[i]
+
+    dat = array.data(deepcopy=False)
+    assert dat is array._data
+
 
 @pytest.mark.parallel(nprocs=4)
 @pytest.mark.parametrize("partition", partitions)


### PR DESCRIPTION
This adds a `copy()` method to `SharedArray` which returns a numpy array of the global data.
This is useful if you need to pass to a function expecting a normal array, or you want to modify the data in-place.

Also extends `synchronise` method to be able to synchronise to only one rank. In this case the data in the full array is valid on the root rank, but on all other ranks non-local array elements remain invalid.