### PR TITLE
Factor handling complex function space out of `DiagFFTPC`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,8 +43,6 @@ jobs:
           . /home/firedrake/firedrake/bin/activate
           python -m pip install pytest-timeout
           python -m pip install pytest-cov
-          git clone https://github.com/JHopeCollins/complex-proxy.git
-          python -m pip install -e complex-proxy
       - name: Install
         run: |
           . /home/firedrake/firedrake/bin/activate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
           . /home/firedrake/firedrake/bin/activate
           python -m pip install pytest-timeout
           python -m pip install pytest-cov
+          python -m pip uninstall --yes pytest-mpi
       - name: Install
         run: |
           . /home/firedrake/firedrake/bin/activate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,8 @@ jobs:
           . /home/firedrake/firedrake/bin/activate
           python -m pip install pytest-timeout
           python -m pip install pytest-cov
+          git clone https://github.com/JHopeCollins/complex-proxy.git
+          python -m pip install -e complex-proxy
       - name: Install
         run: |
           . /home/firedrake/firedrake/bin/activate

--- a/asQ/__init__.py
+++ b/asQ/__init__.py
@@ -9,3 +9,4 @@ from .post import (write_timesteps,  # noqa: F401
                    write_aaos_solve_metrics,  # noqa: F401
                    write_block_solve_metrics,  # noqa: F401
                    write_paradiag_metrics)  # noqa: F401
+import complex_proxy  # noqa: F401

--- a/asQ/__init__.py
+++ b/asQ/__init__.py
@@ -9,4 +9,4 @@ from .post import (write_timesteps,  # noqa: F401
                    write_aaos_solve_metrics,  # noqa: F401
                    write_block_solve_metrics,  # noqa: F401
                    write_paradiag_metrics)  # noqa: F401
-import complex_proxy  # noqa: F401
+import .complex_proxy  # noqa: F401

--- a/asQ/__init__.py
+++ b/asQ/__init__.py
@@ -9,4 +9,4 @@ from .post import (write_timesteps,  # noqa: F401
                    write_aaos_solve_metrics,  # noqa: F401
                    write_block_solve_metrics,  # noqa: F401
                    write_paradiag_metrics)  # noqa: F401
-import .complex_proxy  # noqa: F401
+from asQ import complex_proxy  # noqa: F401

--- a/asQ/complex_proxy/__init__.py
+++ b/asQ/complex_proxy/__init__.py
@@ -1,0 +1,2 @@
+import complex_proxy.mixed  # noqa: F401, F403
+import complex_proxy.vector  # noqa: F401, F403

--- a/asQ/complex_proxy/__init__.py
+++ b/asQ/complex_proxy/__init__.py
@@ -1,2 +1,2 @@
-import complex_proxy.mixed  # noqa: F401, F403
-import complex_proxy.vector  # noqa: F401, F403
+import asQ.complex_proxy.mixed  # noqa: F401, F403
+import asQ.complex_proxy.vector  # noqa: F401, F403

--- a/asQ/complex_proxy/common.py
+++ b/asQ/complex_proxy/common.py
@@ -1,0 +1,103 @@
+
+from enum import IntEnum
+
+# flags for real and imaginary parts
+Part = IntEnum("Part", (("Real", 0), ("Imag", 1)))
+re = Part.Real
+im = Part.Imag
+
+api_names = ["FiniteElement", "FunctionSpace", "DirichletBC",
+             "split", "subfunctions",
+             "get_real", "get_imag", "set_real", "set_imag",
+             "LinearForm", "BilinearForm", "derivative",
+             "Part", "re", "im"]
+
+
+def _flatten_tree(root, is_leaf, get_children, container=tuple):
+    """
+    Return the recursively flattened tree below root in the order that the leafs appear in the traversal.
+
+    :arg root: the current root node.
+    :arg is_leaf: predicate on root returning True if root has no children.
+    :arg get_children: unary op on root that returns an iterable of root's children if is_leaf(root) evaluates False.
+    :arg container: the container type to return the flattened tree in.
+    """
+    if is_leaf(root):
+        return container((root,))
+    else:
+        return container((leaf
+                          for child in get_children(root)
+                          for leaf in _flatten_tree(child, is_leaf, get_children)))
+
+
+def _build_twoform(W, z, A, u, split, return_z):
+    """
+    Return a bilinear Form on the complex FunctionSpace W equal to a complex multiple of a bilinear Form on the real FunctionSpace.
+    If z = zr + i*zi is a complex number, u = ur + i*ui is a complex (Trial)Function, and b = br + i*bi is a complex linear Form, we want to construct a Form such that (zA)u=b
+
+    (zA)u = (zr*A + i*zi*A)(ur + i*ui)
+          = (zr*A*ur - zi*A*ui) + i*(zr*A*ui + zi*A*ur)
+
+          = | zr*A   -zi*A | | ur | = | br |
+            |              | |    |   |    |
+            | zi*A    zr*A | | ui | = | bi |
+
+    :arg W: the complex-proxy FunctionSpace
+    :arg z: a complex number.
+    :arg A: a generator function for a bilinear Form on the real FunctionSpace, callable as A(*u, *v) where u and v are TrialFunctions and TestFunctions on the real FunctionSpace.
+    :arg u: a Function or TrialFunction on the complex space
+    :arg return_z: If true, return Constants for the real/imaginary parts of z used in the BilinearForm.
+    """
+    from firedrake import TestFunction, Constant
+
+    v = TestFunction(W)
+
+    ur = split(u, Part.Real)
+    ui = split(u, Part.Imag)
+
+    vr = split(v, Part.Real)
+    vi = split(v, Part.Imag)
+
+    zr = Constant(z.real)
+    zi = Constant(z.imag)
+
+    A11 = zr*A(*ur, *vr)
+    A12 = -zi*A(*ui, *vr)
+    A21 = zi*A(*ur, *vi)
+    A22 = zr*A(*ui, *vi)
+    Ac = A11 + A12 + A21 + A22
+
+    if return_z:
+        return Ac, zr, zi
+    else:
+        return Ac
+
+
+def _build_oneform(W, z, f, split, return_z):
+    """
+    Return a Linear Form on the complex FunctionSpace W equal to a complex multiple of a linear Form on the real FunctionSpace.
+    If z = zr + i*zi is a complex number, v = vr + i*vi is a complex TestFunction, we want to construct the Form:
+    <zr*vr,f> + i<zi*vi,f>
+
+    :arg W: the complex-proxy FunctionSpace.
+    :arg z: a complex number.
+    :arg f: a generator function for a linear Form on the real FunctionSpace, callable as f(*v) where v are TestFunctions on the real FunctionSpace.
+    :arg return_z: If true, return Constants for the real/imaginary parts of z used in the LinearForm.
+    """
+    from firedrake import TestFunction, Constant
+
+    v = TestFunction(W)
+    vr = split(v, Part.Real)
+    vi = split(v, Part.Imag)
+
+    zr = Constant(z.real)
+    zi = Constant(z.imag)
+
+    fr = zr*f(*vr)
+    fi = zi*f(*vi)
+    fc = fr + fi
+
+    if return_z:
+        return fc, zr, zi
+    else:
+        return fc

--- a/asQ/complex_proxy/mixed.py
+++ b/asQ/complex_proxy/mixed.py
@@ -1,0 +1,1 @@
+from complex_proxy.mixed_impl import *  # noqa: F401, F403

--- a/asQ/complex_proxy/mixed.py
+++ b/asQ/complex_proxy/mixed.py
@@ -1,1 +1,1 @@
-from complex_proxy.mixed_impl import *  # noqa: F401, F403
+from asQ.complex_proxy.mixed_impl import *  # noqa: F401, F403

--- a/asQ/complex_proxy/mixed_impl.py
+++ b/asQ/complex_proxy/mixed_impl.py
@@ -1,9 +1,9 @@
 
 import firedrake as fd
 
-from complex_proxy.common import (Part, re, im, api_names,  # noqa:F401
-                                  _flatten_tree,
-                                  _build_oneform, _build_twoform)  # noqa: F401
+from asQ.complex_proxy.common import (Part, re, im, api_names,  # noqa:F401
+                                      _flatten_tree,
+                                      _build_oneform, _build_twoform)  # noqa: F401
 
 __all__ = api_names
 

--- a/asQ/complex_proxy/mixed_impl.py
+++ b/asQ/complex_proxy/mixed_impl.py
@@ -1,0 +1,239 @@
+
+import firedrake as fd
+
+from complex_proxy.common import (Part, re, im, api_names,  # noqa:F401
+                                  _flatten_tree,
+                                  _build_oneform, _build_twoform)  # noqa: F401
+
+__all__ = api_names
+
+
+def FiniteElement(elem):
+    """
+    Return a UFL FiniteElement which proxies a complex version of the real-valued UFL FiniteElement elem.
+
+    The returned complex-valued element has twice as many components as the real-valued element, with
+    each component of the real-valued element having a corresponding 'real' and 'imaginary' part eg:
+    Non-mixed real elements become 2-component MixedElements.
+    Mixed real elements become MixedElements with 2*len(elem.num_sub_elements()) components.
+    Nested MixedElements are flattened before being proxied.
+
+    :arg elem: the UFL FiniteElement to be proxied
+    """
+    flat_elems = _flatten_tree(elem,
+                               is_leaf=lambda e: type(e) is not fd.MixedElement,
+                               get_children=lambda e: e.sub_elements())
+
+    return fd.MixedElement([e for ee in zip(flat_elems, flat_elems) for e in ee])
+
+
+def compatible_ufl_elements(elemc, elemr):
+    """
+    Return whether the ufl element elemc is a complex proxy for real ufl element elemr
+
+    :arg elemc: complex proxy ufl element
+    :arg elemr: real ufl element
+    """
+    return elemc == FiniteElement(elemr)
+
+
+def FunctionSpace(V):
+    """
+    Return a FunctionSpace which proxies a complex version of the real FunctionSpace V.
+
+    The returned complex-valued function space has twice as many components as the real-valued element, with
+    each component of the real-valued function space having a corresponding 'real' and 'imaginary' part eg:
+    Non-mixed real function spaces become 2-component MixedFunctionSpaces.
+    Mixed real function spaces become MixedFunctionSpaces with 2*len(V.ufl_element().num_sub_elements()) components.
+    Function spaces with nested MixedElements are flattened before being proxied.
+
+    :arg V: the real-valued function space.
+    """
+    return fd.FunctionSpace(V.mesh(), FiniteElement(V.ufl_element()))
+
+
+def DirichletBC(W, V, bc, function_arg=None):
+    """
+    Return a DirichletBC on the complex FunctionSpace W that is equivalent to the DirichletBC bc on the real FunctionSpace V that W was constructed from.
+
+    :arg W: the complex FunctionSpace.
+    :arg V: the real FunctionSpace that W was constructed from.
+    :arg bc: a DirichletBC on the real FunctionSpace that W was constructed from.
+    """
+    if type(V.ufl_element()) is fd.MixedElement:
+        off = 2*bc.function_space().index
+    else:
+        off = 0
+
+    if function_arg is None:
+        function_arg = bc.function_arg
+
+    return tuple((fd.DirichletBC(W.sub(off+i), function_arg, bc.sub_domain)
+                  for i in range(2)))
+
+
+def _component_elements(us, i):
+    """
+    Return a tuple of the real or imaginary components of the iterable us
+
+    :arg us: an iterable having the same number of elements as the complex function space
+                i.e. twice the number of components as the real function space.
+    :arg i: the index of the components, Part.Real for real or Part.Imag for imaginary.
+    """
+    if not isinstance(i, Part):
+        raise TypeError("i must be a Part enum")
+    return tuple(us[i::2])
+
+
+def split(u, i):
+    """
+    If u is a Coefficient or Argument in the complex FunctionSpace,
+        returns a tuple with the function components corresponding
+        to the real or imaginary subelements, indexed appropriately.
+        Analogous to firedrake.split(u)
+
+    :arg u: a Coefficient or Argument in the complex FunctionSpace
+    :arg i: the index of the components, Part.Real for real or Part.Imag for imaginary.
+    """
+    return _component_elements(fd.split(u), i)
+
+
+def subfunctions(u, i):
+    """
+    Return a tuple of the real or imaginary components of the complex function u. Analogous to u.subfunctions.
+
+    :arg u: a complex Function.
+    :arg i: the index of the components, Part.Real for real or Part.Imag for imaginary.
+    """
+    usub = u if type(u) is tuple else u.subfunctions
+    return _component_elements(usub, i)
+
+
+def _get_part(u, vout, i):
+    """
+    Copy the real or imaginary part of the complex Function u into the real-valued Function vout.
+
+    :arg u: a complex Function.
+    :arg vout: a real-valued Function.
+    :arg i: the index of the components, Part.Real for real or Part.Imag for imaginary.
+    """
+    usub = subfunctions(u, i)
+    vsub = vout if type(vout) is tuple else vout.subfunctions
+
+    for csub, rsub in zip(usub, vsub):
+        rsub.assign(csub)
+
+    return vout
+
+
+def _set_part(u, vnew, i):
+    """
+    Set the real or imaginary part of the complex Function u to the value of the real Function vnew.
+
+    :arg u: a complex Function.
+    :arg vnew: a real Function.
+    :arg i: the index of the components, Part.Real for real or Part.Imag for imaginary.
+    """
+    usub = subfunctions(u, i)
+    vsub = vnew if type(vnew) is tuple else vnew.subfunctions
+
+    for csub, rsub in zip(usub, vsub):
+        csub.assign(rsub)
+
+
+def get_real(u, vout):
+    """
+    Copy the real component of the complex Function u into the real-valued Function vout
+
+    :arg u: a complex Function.
+    :arg vout: A real-valued function that real component of u is copied into.
+    """
+    return _get_part(u, vout, Part.Real)
+
+
+def get_imag(u, vout, name=None):
+    """
+    Copy the imaginary component of the complex Function u into the real-valued Function vout
+
+    :arg u: a complex Function.
+    :arg vout: A real-valued function that imaginary component of u is copied into.
+    """
+    return _get_part(u, vout, Part.Imag)
+
+
+def set_real(u, vnew):
+    """
+    Copy the real-valued Function vnew into the real part of the complex Function u.
+
+    :arg u: a complex Function.
+    :arg vnew: A real-value Function.
+    """
+    _set_part(u, vnew, Part.Real)
+
+
+def set_imag(u, vnew):
+    """
+    Copy the real-valued Function vnew into the imaginary part of the complex Function u.
+
+    :arg u: a complex Function.
+    :arg vnew: A real-value Function.
+    """
+    _set_part(u, vnew, Part.Imag)
+
+
+def LinearForm(W, z, f, return_z=False):
+    """
+    Return a Linear Form on the complex FunctionSpace W equal to a complex multiple of a linear Form on the real FunctionSpace.
+    If z = zr + i*zi is a complex number, v = vr + i*vi is a complex TestFunction, we want to construct the Form:
+    <zr*vr,f> + i<zi*vi,f>
+
+    :arg W: the complex-proxy FunctionSpace.
+    :arg z: a complex number.
+    :arg f: a generator function for a linear Form on the real FunctionSpace, callable as f(*v) where v are TestFunctions on the real FunctionSpace.
+    :arg return_z: If true, return Constants for the real/imaginary parts of z used in the LinearForm.
+    """
+    return _build_oneform(W, z, f, split, return_z)
+
+
+def BilinearForm(W, z, A, return_z=False):
+    """
+    Return a bilinear Form on the complex FunctionSpace W equal to a complex multiple of a bilinear Form on the real FunctionSpace.
+    If z = zr + i*zi is a complex number, u = ur + i*ui is a complex TrialFunction, and b = br + i*bi is a complex linear Form, we want to construct a Form such that (zA)u=b
+
+    (zA)u = (zr*A + i*zi*A)(ur + i*ui)
+          = (zr*A*ur - zi*A*ui) + i*(zr*A*ui + zi*A*ur)
+
+          = | zr*A   -zi*A | | ur | = | br |
+            |              | |    |   |    |
+            | zi*A    zr*A | | ui | = | bi |
+
+    :arg W: the complex-proxy FunctionSpace
+    :arg z: a complex number.
+    :arg A: a generator function for a bilinear Form on the real FunctionSpace, callable as A(*u, *v) where u and v are TrialFunctions and TestFunctions on the real FunctionSpace.
+    :arg return_z: If true, return Constants for the real/imaginary parts of z used in the BilinearForm.
+    """
+    return _build_twoform(W, z, A, fd.TrialFunction(W), split, return_z)
+
+
+def derivative(z, F, u, return_z=False):
+    """
+    Return a bilinear Form equivalent to z*J where z is a complex number, J = dF/dw, F is a nonlinear Form on the real-valued space, and w is a function in the real-valued space. The real and imaginary components of the complex function u most both be equal to w for this operation to be valid.
+
+    If z = zr + i*zi is a complex number, x = xr + i*xi is a complex Function, b = br + i*bi is a complex linear Form, J is the bilinear Form dF/dw, we want to construct a Form such that (zJ)x=b
+
+    (zJ)x = (zr*J + i*zi*J)(xr + i*xi)
+          = (zr*J*xr - zi*J*xi) + i*(zr*A*xi + zi*A*xr)
+
+          = | zr*J   -zi*J | | xr | = | br |
+            |              | |    |   |    |
+            | zi*J    zr*J | | xi | = | bi |
+
+    :arg z: a complex number.
+    :arg F: a generator function for a nonlinear Form on the real FunctionSpace, callable as F(*u, *v) where u and v are Functions and TestFunctions on the real FunctionSpace.
+    :arg u: the Function to differentiate F with respect to
+    :arg return_z: If true, return Constants for the real/imaginary parts of z used in the BilinearForm.
+    """
+    def A(*args):
+        return fd.derivative(F(*args), u)
+
+    return _build_twoform(u.function_space(), z, A, u, split, return_z)

--- a/asQ/complex_proxy/mixed_impl.py
+++ b/asQ/complex_proxy/mixed_impl.py
@@ -41,13 +41,13 @@ def FunctionSpace(V):
     """
     Return a FunctionSpace which proxies a complex version of the real FunctionSpace V.
 
-    The returned complex-valued function space has twice as many components as the real-valued element, with
-    each component of the real-valued function space having a corresponding 'real' and 'imaginary' part eg:
-    Non-mixed real function spaces become 2-component MixedFunctionSpaces.
-    Mixed real function spaces become MixedFunctionSpaces with 2*len(V.ufl_element().num_sub_elements()) components.
+    The returned complex-valued FunctionSpace has twice as many components as the real-valued element, with
+    each component of the real-valued FunctionSpace having a corresponding 'real' and 'imaginary' part eg:
+    Non-mixed real FunctionSpaces become 2-component MixedFunctionSpaces.
+    Mixed real FunctionSpaces become MixedFunctionSpaces with 2*len(V.ufl_element().num_sub_elements()) components.
     Function spaces with nested MixedElements are flattened before being proxied.
 
-    :arg V: the real-valued function space.
+    :arg V: the real-valued FunctionSpace.
     """
     return fd.FunctionSpace(V.mesh(), FiniteElement(V.ufl_element()))
 
@@ -76,8 +76,8 @@ def _component_elements(us, i):
     """
     Return a tuple of the real or imaginary components of the iterable us
 
-    :arg us: an iterable having the same number of elements as the complex function space
-                i.e. twice the number of components as the real function space.
+    :arg us: an iterable having the same number of elements as the complex FunctionSpace
+                i.e. twice the number of components as the real FunctionSpace.
     :arg i: the index of the components, Part.Real for real or Part.Imag for imaginary.
     """
     if not isinstance(i, Part):
@@ -88,7 +88,7 @@ def _component_elements(us, i):
 def split(u, i):
     """
     If u is a Coefficient or Argument in the complex FunctionSpace,
-        returns a tuple with the function components corresponding
+        returns a tuple with the Function components corresponding
         to the real or imaginary subelements, indexed appropriately.
         Analogous to firedrake.split(u)
 
@@ -100,7 +100,7 @@ def split(u, i):
 
 def subfunctions(u, i):
     """
-    Return a tuple of the real or imaginary components of the complex function u. Analogous to u.subfunctions.
+    Return a tuple of the real or imaginary components of the complex Function u. Analogous to u.subfunctions.
 
     :arg u: a complex Function.
     :arg i: the index of the components, Part.Real for real or Part.Imag for imaginary.
@@ -146,7 +146,7 @@ def get_real(u, vout):
     Copy the real component of the complex Function u into the real-valued Function vout
 
     :arg u: a complex Function.
-    :arg vout: A real-valued function that real component of u is copied into.
+    :arg vout: A real-valued Function that real component of u is copied into.
     """
     return _get_part(u, vout, Part.Real)
 
@@ -156,7 +156,7 @@ def get_imag(u, vout, name=None):
     Copy the imaginary component of the complex Function u into the real-valued Function vout
 
     :arg u: a complex Function.
-    :arg vout: A real-valued function that imaginary component of u is copied into.
+    :arg vout: A real-valued Function that imaginary component of u is copied into.
     """
     return _get_part(u, vout, Part.Imag)
 
@@ -217,7 +217,7 @@ def BilinearForm(W, z, A, return_z=False):
 
 def derivative(z, F, u, return_z=False):
     """
-    Return a bilinear Form equivalent to z*J where z is a complex number, J = dF/dw, F is a nonlinear Form on the real-valued space, and w is a function in the real-valued space. The real and imaginary components of the complex function u most both be equal to w for this operation to be valid.
+    Return a bilinear Form equivalent to z*J where z is a complex number, J = dF/dw, F is a nonlinear Form on the real-valued space, and w is a Function in the real-valued space. The real and imaginary components of the complex Function u most both be equal to w for this operation to be valid.
 
     If z = zr + i*zi is a complex number, x = xr + i*xi is a complex Function, b = br + i*bi is a complex linear Form, J is the bilinear Form dF/dw, we want to construct a Form such that (zJ)x=b
 

--- a/asQ/complex_proxy/vector.py
+++ b/asQ/complex_proxy/vector.py
@@ -1,1 +1,1 @@
-from complex_proxy.vector_impl import *  # noqa: F401, F403
+from asQ.complex_proxy.vector_impl import *  # noqa: F401, F403

--- a/asQ/complex_proxy/vector.py
+++ b/asQ/complex_proxy/vector.py
@@ -1,0 +1,1 @@
+from complex_proxy.vector_impl import *  # noqa: F401, F403

--- a/asQ/complex_proxy/vector_impl.py
+++ b/asQ/complex_proxy/vector_impl.py
@@ -3,8 +3,8 @@ import firedrake as fd
 
 from ufl.classes import MultiIndex, FixedIndex, Indexed
 
-from complex_proxy.common import (Part, re, im, api_names,  # noqa:F401
-                                  _build_oneform, _build_twoform)  # noqa: F401
+from asQ.complex_proxy.common import (Part, re, im, api_names,  # noqa:F401
+                                      _build_oneform, _build_twoform)  # noqa: F401
 
 __all__ = api_names
 

--- a/asQ/complex_proxy/vector_impl.py
+++ b/asQ/complex_proxy/vector_impl.py
@@ -51,12 +51,12 @@ def FunctionSpace(V):
     """
     Return a FunctionSpace which proxies a complex version of the real FunctionSpace V.
 
-    The returned complex-valued function space has as many components as the real-valued function space, but each component has a 'real' and 'imaginary' part eg:
-    Scalar components of the real-valued function space become 2-vector components of the complex-valued space.
-    n-vector components of the real-valued function space become 2xn-tensor components of the complex-valued space.
-    (shape)-tensor components of the real-valued function space become (2,shape)-tensor components of the complex-valued space.
+    The returned complex-valued Function space has as many components as the real-valued FunctionSpace, but each component has a 'real' and 'imaginary' part eg:
+    Scalar components of the real-valued FunctionSpace become 2-vector components of the complex-valued space.
+    n-vector components of the real-valued FunctionSpace become 2xn-tensor components of the complex-valued space.
+    (shape)-tensor components of the real-valued FunctionSpace become (2,shape)-tensor components of the complex-valued FunctionSpace.
 
-    :arg V: the real-valued function space.
+    :arg V: the real-valued FunctionSpace.
     """
     return fd.FunctionSpace(V.mesh(), FiniteElement(V.ufl_element()))
 
@@ -86,7 +86,7 @@ def DirichletBC(W, V, bc, function_arg=None):
 def split(u, i):
     """
     If u is a Coefficient or Argument in the complex FunctionSpace,
-        returns a tuple with the function components corresponding
+        returns a tuple with the Function components corresponding
         to the real or imaginary subelements, indexed appropriately.
 
     :arg u: a Coefficient or Argument in the complex FunctionSpace
@@ -112,7 +112,7 @@ def split(u, i):
 
 def subfunctions(u, i):
     """
-    Return a tuple of the real or imaginary components of the complex function u. Analogous to u.subfunctions.
+    Return a tuple of the real or imaginary components of the complex Function u. Analogous to u.subfunctions.
 
     :arg u: a complex Function.
     :arg i: the index of the components, Part.Real for real or Part.Imag for imaginary.
@@ -132,7 +132,7 @@ def subfunctions(u, i):
         return tuple((w for v in u.subfunctions for w in subfunctions(v, i)))
 
     else:
-        raise ValueError("u must be a function from a complex-proxy FunctionSpace")
+        raise ValueError("u must be a Function from a complex-proxy FunctionSpace")
 
 
 def _get_part(u, vout, i):
@@ -249,7 +249,7 @@ def BilinearForm(W, z, A, return_z=False):
 
 def derivative(z, F, u, return_z=False):
     """
-    Return a bilinear Form equivalent to z*J where z is a complex number, J = dF/dw, F is a nonlinear Form on the real-valued space, and w is a function in the real-valued space. The real and imaginary components of the complex function u most both be equal to w for this operation to be valid.
+    Return a bilinear Form equivalent to z*J where z is a complex number, J = dF/dw, F is a nonlinear Form on the real-valued space, and w is a Function in the real-valued space. The real and imaginary components of the complex Function u most both be equal to w for this operation to be valid.
 
     If z = zr + i*zi is a complex number, x = xr + i*xi is a complex Function, b = br + i*bi is a complex linear Form, J is the bilinear Form dF/dw, we want to construct a Form such that (zJ)x=b
 

--- a/asQ/complex_proxy/vector_impl.py
+++ b/asQ/complex_proxy/vector_impl.py
@@ -1,0 +1,271 @@
+
+import firedrake as fd
+
+from ufl.classes import MultiIndex, FixedIndex, Indexed
+
+from complex_proxy.common import (Part, re, im, api_names,  # noqa:F401
+                                  _build_oneform, _build_twoform)  # noqa: F401
+
+__all__ = api_names
+
+
+def FiniteElement(elem):
+    """
+    Return a UFL FiniteElement which proxies a complex version of the real UFL FiniteElement elem.
+
+    The returned complex-valued element has as many components as the real-valued element, but each component has a 'real' and 'imaginary' part eg:
+    Scalar real elements become 2-vector complex elements.
+    n-vector real elements become 2xn-tensor complex elements
+    (shape)-tensor real elements become (2,shape)-tensor complex elements
+
+    :arg elem: the UFL FiniteElement to be proxied
+    """
+    if isinstance(elem, fd.TensorElement):
+        shape = (2,) + elem._shape
+        scalar_element = elem.sub_elements()[0]
+        return fd.TensorElement(scalar_element, shape=shape)
+
+    elif isinstance(elem, fd.VectorElement):
+        shape = (2, elem.num_sub_elements())
+        scalar_element = elem.sub_elements()[0]
+        return fd.TensorElement(scalar_element, shape=shape)
+
+    elif isinstance(elem, fd.MixedElement):  # recurse
+        return fd.MixedElement([FiniteElement(e) for e in elem.sub_elements()])
+
+    else:
+        return fd.VectorElement(elem, dim=2)
+
+
+def compatible_ufl_elements(elemc, elemr):
+    """
+    Return whether the ufl element elemc is a complex proxy for real ufl element elemr
+
+    :arg elemc: complex proxy ufl element
+    :arg elemr: real ufl element
+    """
+    return elemc == FiniteElement(elemr)
+
+
+def FunctionSpace(V):
+    """
+    Return a FunctionSpace which proxies a complex version of the real FunctionSpace V.
+
+    The returned complex-valued function space has as many components as the real-valued function space, but each component has a 'real' and 'imaginary' part eg:
+    Scalar components of the real-valued function space become 2-vector components of the complex-valued space.
+    n-vector components of the real-valued function space become 2xn-tensor components of the complex-valued space.
+    (shape)-tensor components of the real-valued function space become (2,shape)-tensor components of the complex-valued space.
+
+    :arg V: the real-valued function space.
+    """
+    return fd.FunctionSpace(V.mesh(), FiniteElement(V.ufl_element()))
+
+
+def DirichletBC(W, V, bc, function_arg=None):
+    """
+    Return a DirichletBC on the complex FunctionSpace W that is equivalent to the DirichletBC bc on the real FunctionSpace V that W was constructed from.
+
+    :arg W: the complex FunctionSpace.
+    :arg V: the real FunctionSpace that W was constructed from.
+    :arg bc: a DirichletBC on the real FunctionSpace that W was constructed from.
+    """
+    if function_arg is None:
+        function_arg = bc.function_arg
+
+    sub_domain = bc.sub_domain
+
+    if type(V.ufl_element()) is fd.MixedElement:
+        idx = bc.function_space().index
+        Ws = (W.sub(idx).sub(0), W.sub(idx).sub(1))
+    else:
+        Ws = (W.sub(0), W.sub(1))
+
+    return tuple(fd.DirichletBC(Wsub, function_arg, sub_domain) for Wsub in Ws)
+
+
+def split(u, i):
+    """
+    If u is a Coefficient or Argument in the complex FunctionSpace,
+        returns a tuple with the function components corresponding
+        to the real or imaginary subelements, indexed appropriately.
+
+    :arg u: a Coefficient or Argument in the complex FunctionSpace
+    :arg i: Part.Real for real subelements, Part.Imag for imaginary elements
+    """
+    if not isinstance(i, Part):
+        raise ValueError("i must be a Part enum")
+
+    us = fd.split(u)
+
+    ncomponents = len(u.function_space().subfunctions)
+
+    if ncomponents == 1:
+        return tuple((us[i],))
+
+    def get_sub_element(cpt, i):
+        part = us[cpt]
+        idxs = fd.indices(len(part.ufl_shape) - 1)
+        return fd.as_tensor(Indexed(part, MultiIndex((FixedIndex(i), *idxs))), idxs)
+
+    return tuple(get_sub_element(cpt, i) for cpt in range(ncomponents))
+
+
+def subfunctions(u, i):
+    """
+    Return a tuple of the real or imaginary components of the complex function u. Analogous to u.subfunctions.
+
+    :arg u: a complex Function.
+    :arg i: the index of the components, Part.Real for real or Part.Imag for imaginary.
+    """
+    if type(u) is tuple:
+        return tuple(v.sub(i) for v in u)
+
+    elem = u.ufl_element()
+    if isinstance(elem, fd.TensorElement):
+        num_sub_real = elem.num_sub_elements()//2
+        return tuple((u.sub(i*num_sub_real + j) for j in range(num_sub_real)))
+
+    elif isinstance(elem, fd.VectorElement):
+        return tuple((u.sub(i),))
+
+    elif isinstance(elem, fd.MixedElement):
+        return tuple((w for v in u.subfunctions for w in subfunctions(v, i)))
+
+    else:
+        raise ValueError("u must be a function from a complex-proxy FunctionSpace")
+
+
+def _get_part(u, vout, i):
+    """
+    Get the real or imaginary part of the complex Function u and copy it to real Function vout.
+
+    :arg u: a complex Function.
+    :arg vout: a real Function.
+    :arg i: the index of the components, Part.Real for real or Part.Imag for imaginary.
+    """
+    usub = subfunctions(u, i)
+    vsub = vout if type(vout) is tuple else vout.subfunctions
+
+    for csub, rsub in zip(usub, vsub):
+        rsub.assign(csub)
+
+    return vout
+
+
+def _set_part(u, vnew, i):
+    """
+    Set the real or imaginary part of the complex Function u to the value of the real Function vnew.
+
+    :arg u: a complex Function.
+    :arg vnew: a real Function.
+    :arg i: the index of the components, Part.Real for real or Part.Imag for imaginary.
+    """
+    usub = subfunctions(u, i)
+    vsub = vnew if type(vnew) is tuple else vnew.subfunctions
+
+    for csub, rsub in zip(usub, vsub):
+        csub.assign(rsub)
+
+
+def get_real(u, vout, name=None):
+    """
+    Return a real Function equal to the real component of the complex Function u.
+
+    :arg u: a complex Function.
+    :arg vout: If a real Function then real component of u is placed here. NotImplementedError(If None then a new Function is returned.)
+    :arg name: If vout is None, the name of the new Function. Ignored if vout is not none.
+    """
+    if vout is None:
+        raise NotImplementedError("Inferring real FunctionSpace from complex FunctionSpace not implemented yet")
+    return _get_part(u, vout, Part.Real)
+
+
+def get_imag(u, vout, name=None):
+    """
+    Return a real Function equal to the imaginary component of the complex Function u.
+
+    :arg u: a complex Function.
+    :arg vout: If a real Function then the imaginary component of u is placed here. NotImplementedError(If None then a new Function is returned.)
+    :arg name: If vout is None, the name of the new Function. Ignored if uout is not none.
+    """
+    if vout is None:
+        raise NotImplementedError("Inferring real FunctionSpace from complex FunctionSpace not implemented yet")
+    return _get_part(u, vout, Part.Imag)
+
+
+def set_real(u, vnew):
+    """
+    Set the real component of the complex Function u to the value of the real Function vnew.
+
+    :arg u: a complex Function.
+    :arg vnew: A real Function.
+    """
+    _set_part(u, vnew, Part.Real)
+
+
+def set_imag(u, vnew):
+    """
+    Set the imaginary component of the complex Function u to the value of the real Function vnew.
+
+    :arg u: a complex Function.
+    :arg vnew: A real Function.
+    """
+    _set_part(u, vnew, Part.Imag)
+
+
+def LinearForm(W, z, f, return_z=False):
+    """
+    Return a Linear Form on the complex FunctionSpace W equal to a complex multiple of a linear Form on the real FunctionSpace.
+    If z = zr + i*zi is a complex number, v = vr + i*vi is a complex TestFunction, we want to construct the Form:
+    <zr*vr,f> + i<zi*vi,f>
+
+    :arg W: the complex-proxy FunctionSpace.
+    :arg z: a complex number.
+    :arg f: a generator function for a linear Form on the real FunctionSpace, callable as f(*v) where v are TestFunctions on the real FunctionSpace.
+    :arg return_z: If true, return Constants for the real/imaginary parts of z used in the LinearForm.
+    """
+    return _build_oneform(W, z, f, split, return_z)
+
+
+def BilinearForm(W, z, A, return_z=False):
+    """
+    Return a bilinear Form on the complex FunctionSpace W equal to a complex multiple of a bilinear Form on the real FunctionSpace.
+    If z = zr + i*zi is a complex number, u = ur + i*ui is a complex TrialFunction, and b = br + i*bi is a complex linear Form, we want to construct a Form such that (zA)u=b
+
+    (zA)u = (zr*A + i*zi*A)(ur + i*ui)
+          = (zr*A*ur - zi*A*ui) + i*(zr*A*ui + zi*A*ur)
+
+          = | zr*A   -zi*A | | ur | = | br |
+            |              | |    |   |    |
+            | zi*A    zr*A | | ui | = | bi |
+
+    :arg W: the complex-proxy FunctionSpace
+    :arg z: a complex number.
+    :arg A: a generator function for a bilinear Form on the real FunctionSpace, callable as A(*u, *v) where u and v are TrialFunctions and TestFunctions on the real FunctionSpace.
+    :arg return_z: If true, return Constants for the real/imaginary parts of z used in the BilinearForm.
+    """
+    return _build_twoform(W, z, A, fd.TrialFunction(W), split, return_z)
+
+
+def derivative(z, F, u, return_z=False):
+    """
+    Return a bilinear Form equivalent to z*J where z is a complex number, J = dF/dw, F is a nonlinear Form on the real-valued space, and w is a function in the real-valued space. The real and imaginary components of the complex function u most both be equal to w for this operation to be valid.
+
+    If z = zr + i*zi is a complex number, x = xr + i*xi is a complex Function, b = br + i*bi is a complex linear Form, J is the bilinear Form dF/dw, we want to construct a Form such that (zJ)x=b
+
+    (zJ)x = (zr*J + i*zi*J)(xr + i*xi)
+          = (zr*J*xr - zi*J*xi) + i*(zr*A*xi + zi*A*xr)
+
+          = | zr*J   -zi*J | | xr | = | br |
+            |              | |    |   |    |
+            | zi*J    zr*J | | xi | = | bi |
+
+    :arg z: a complex number.
+    :arg F: a generator function for a nonlinear Form on the real FunctionSpace, callable as F(*u, *v) where u and v are Functions and TestFunctions on the real FunctionSpace.
+    :arg u: the Function to differentiate F with respect to
+    :arg return_z: If true, return Constants for the real/imaginary parts of z used in the BilinearForm.
+    """
+    def A(*args):
+        return fd.derivative(F(*args), u)
+
+    return _build_twoform(u.function_space(), z, A, u, split, return_z)

--- a/asQ/diag_preconditioner.py
+++ b/asQ/diag_preconditioner.py
@@ -10,6 +10,8 @@ import importlib
 from ufl.classes import MultiIndex, FixedIndex, Indexed
 from .profiling import memprofile
 
+import complex_proxy.vector as cpx
+
 
 class DiagFFTPC(object):
     prefix = "diagfft_"
@@ -110,25 +112,7 @@ class DiagFFTPC(object):
         mesh = self.blockV.mesh()
         Ve = self.blockV.ufl_element()
         self.ncpts = len(self.blockV)
-        V_cpts = self.blockV.subfunctions
-        ComplexCpts = []
-        for V_cpt in V_cpts:
-            rank = V_cpt.rank
-            V_cpt_ele = V_cpt.ufl_element()
-            if rank == 0:  # scalar basis coefficients
-                ComplexCpts.append(fd.VectorElement(V_cpt_ele, dim=2))
-            elif rank == 1:  # vector basis coefficients
-                dim = V_cpt_ele.num_sub_elements()
-                shape = (2, dim)
-                scalar_element = V_cpt_ele.sub_elements()[0]
-                ComplexCpts.append(fd.TensorElement(scalar_element, shape))
-            else:
-                assert (rank > 0)
-                shape = (2,) + V_cpt_ele._shape
-                scalar_element = V_cpt_ele.sub_elements()[0]
-                ComplexCpts.append(fd.TensorElement(scalar_element, shape))
-        self.CblockV = reduce(mul, [fd.FunctionSpace(mesh, ComplexCpt)
-                                    for ComplexCpt in ComplexCpts])
+        self.CblockV = cpx.FunctionSpace(self.blockV)
 
         # get the boundary conditions
         self.set_CblockV_bcs()

--- a/asQ/diag_preconditioner.py
+++ b/asQ/diag_preconditioner.py
@@ -339,11 +339,8 @@ class DiagFFTPC(object):
             # copy the data into solver input
             self.xtemp.assign(0.)
 
-            Jins = self.xtemp.subfunctions
-
-            for cpt in range(self.ncpts):
-                self.aaos.get_component(i, cpt, wout=Jins[cpt].sub(0), f_alls=self.xfr.subfunctions)
-                self.aaos.get_component(i, cpt, wout=Jins[cpt].sub(1), f_alls=self.xfi.subfunctions)
+            cpx.set_real(self.xtemp, self.aaos.get_field_components(i, f_alls=self.xfr.subfunctions))
+            cpx.set_imag(self.xtemp, self.aaos.get_field_components(i, f_alls=self.xfi.subfunctions))
 
             # Do a project for Riesz map, to be superceded
             # when we get Cofunction
@@ -354,10 +351,8 @@ class DiagFFTPC(object):
             self.Jsolvers[i].solve()
 
             # copy the data from solver output
-            Jpouts = self.Jprob_out.subfunctions
-            for cpt in range(self.ncpts):
-                self.aaos.set_component(i, cpt, Jpouts[cpt].sub(0), f_alls=self.xfr.subfunctions)
-                self.aaos.set_component(i, cpt, Jpouts[cpt].sub(1), f_alls=self.xfi.subfunctions)
+            cpx.get_real(self.Jprob_out, self.aaos.get_field_components(i, f_alls=self.xfr.subfunctions))
+            cpx.get_imag(self.Jprob_out, self.aaos.get_field_components(i, f_alls=self.xfi.subfunctions))
 
         ######################
         # Undiagonalise - Copy, transfer, IFFT, transfer, scale, copy

--- a/asQ/diag_preconditioner.py
+++ b/asQ/diag_preconditioner.py
@@ -153,7 +153,7 @@ class DiagFFTPC(object):
         }
 
         # mixed mass matrices are decoupled so solve seperately
-        if isinstance(self.CblockV.ufl_element(), fd.MixedElement):
+        if isinstance(self.blockV.ufl_element(), fd.MixedElement):
             default_riesz_parameters = {
                 'ksp_type': 'preonly',
                 'mat_type': 'nest',

--- a/asQ/diag_preconditioner.py
+++ b/asQ/diag_preconditioner.py
@@ -7,7 +7,7 @@ from asQ.pencil import Pencil, Subcomm
 import importlib
 from asQ.profiling import memprofile
 
-import complex_proxy.vector as cpx
+import complex_proxy.mixed as cpx
 
 
 class DiagFFTPC(object):
@@ -106,7 +106,6 @@ class DiagFFTPC(object):
         # Block system setup
         # First need to build the vector function space version of
         # blockV
-        Ve = self.blockV.ufl_element()
         self.ncpts = len(self.blockV)
         self.CblockV = cpx.FunctionSpace(self.blockV)
 
@@ -150,11 +149,11 @@ class DiagFFTPC(object):
             'ksp_type': 'preonly',
             'pc_type': 'lu',
             'pc_factor_mat_solver_type': 'mumps',
-            'mat_type': 'baij'
+            'mat_type': 'aij'
         }
 
         # mixed mass matrices are decoupled so solve seperately
-        if isinstance(Ve, fd.MixedElement):
+        if isinstance(self.CblockV.ufl_element(), fd.MixedElement):
             default_riesz_parameters = {
                 'ksp_type': 'preonly',
                 'mat_type': 'nest',

--- a/asQ/diag_preconditioner.py
+++ b/asQ/diag_preconditioner.py
@@ -7,7 +7,7 @@ from asQ.pencil import Pencil, Subcomm
 import importlib
 from asQ.profiling import memprofile
 
-import complex_proxy.vector as cpx
+import asQ.complex_proxy.vector as cpx
 
 
 class DiagFFTPC(object):

--- a/asQ/diag_preconditioner.py
+++ b/asQ/diag_preconditioner.py
@@ -7,7 +7,7 @@ from asQ.pencil import Pencil, Subcomm
 import importlib
 from asQ.profiling import memprofile
 
-import complex_proxy.mixed as cpx
+import complex_proxy.vector as cpx
 
 
 class DiagFFTPC(object):

--- a/tests/test_complex_proxy/test_complex_mixed.py
+++ b/tests/test_complex_proxy/test_complex_mixed.py
@@ -1,0 +1,665 @@
+
+import firedrake as fd
+import asQ.complex_proxy.mixed as cpx
+
+import pytest
+
+
+cell = fd.Cell('triangle')
+
+scalar_elements = [
+    pytest.param(fd.FiniteElement("CG", cell, 1), id="CG1"),
+    pytest.param(fd.FiniteElement("BDM", cell, 2), id="BDM1")
+]
+
+vector_elements = [
+    pytest.param(fd.VectorElement("DG", cell, 1), id="VectorDG1"),
+    pytest.param(fd.VectorElement("DG", cell, 1, dim=3), id="VectorDG1_3D")
+]
+
+tensor_elements = [
+    pytest.param(fd.TensorElement("Lagrange", cell, 1), id="TensorL1"),
+    pytest.param(fd.TensorElement("Lagrange", cell, 1, shape=(2, 3, 4)), id="TensorL1_234D")
+]
+
+elements = scalar_elements + vector_elements + tensor_elements
+
+
+complex_numbers = [2+0j, 0+3j, 3+2j]
+
+
+@pytest.fixture
+def nx():
+    return 10
+
+
+@pytest.fixture
+def mesh(nx):
+    return fd.UnitSquareMesh(nx, nx)
+
+
+@pytest.fixture
+def mixed_element():
+    return fd.MixedElement([param.values[0] for param in elements])
+
+
+@pytest.mark.parametrize("elem", elements)
+def test_finite_element(elem):
+    """
+    Test that the complex proxy FiniteElement is constructed correctly from a real FiniteElement.
+    """
+    celem = cpx.FiniteElement(elem)
+
+    assert celem.num_sub_elements() == 2
+
+    for ce in celem.sub_elements():
+        assert ce == elem
+
+
+def test_mixed_element(mixed_element):
+    """
+    Test that the complex proxy FiniteElement is constructed correctly from a real MixedElement.
+    """
+
+    celem = cpx.FiniteElement(mixed_element)
+
+    assert celem.num_sub_elements() == 2*mixed_element.num_sub_elements()
+
+    csubs = celem.sub_elements()
+    msubs = mixed_element.sub_elements()
+
+    for i in range(mixed_element.num_sub_elements()):
+        assert csubs[2*i+0] == msubs[i]
+        assert csubs[2*i+1] == msubs[i]
+
+
+def test_nested_mixed_element():
+    """
+    Test that the complex proxy FiniteElement is constructed correctly from a nested real MixedElement.
+    """
+    cg = fd.FiniteElement("CG", cell, 1)
+    dg = fd.FiniteElement("DG", cell, 2)
+
+    mixed_elem = fd.MixedElement((cg, dg))
+    nested_elem = fd.MixedElement((mixed_elem, mixed_elem))
+    flat_elem = fd.MixedElement((cg, cg, dg, dg, cg, cg, dg, dg))
+    assert cpx.FiniteElement(nested_elem) == flat_elem
+
+    bdm = fd.FiniteElement("BDM", cell, 1)
+    nested_elem = fd.MixedElement((mixed_elem, bdm))
+    flat_elem = fd.MixedElement((cg, cg, dg, dg, bdm, bdm))
+    assert cpx.FiniteElement(nested_elem) == flat_elem
+
+
+@pytest.mark.parametrize("elem", elements)
+def test_function_space(mesh, elem):
+    """
+    Test that the proxy complex FunctionSpace is correctly constructed for a scalar real FunctionSpace
+    """
+    V = fd.FunctionSpace(mesh, elem)
+    W = cpx.FunctionSpace(V)
+
+    assert W.ufl_element() == cpx.FiniteElement(elem)
+
+
+def test_mixed_function_space(mesh, mixed_element):
+    """
+    Test that the proxy complex FunctionSpace is correctly constructed for a mixed real FunctionSpace
+    """
+
+    V = fd.FunctionSpace(mesh, mixed_element)
+    W = cpx.FunctionSpace(V)
+
+    assert len(W.subfunctions) == 2*len(V.subfunctions)
+
+    for i in range(V.ufl_element().num_sub_elements()):
+        idx_real = 2*i+0
+        idx_imag = 2*i+1
+
+        real_elem = W.subfunctions[idx_real].ufl_element()
+        imag_elem = W.subfunctions[idx_imag].ufl_element()
+        orig_elem = V.subfunctions[i].ufl_element()
+
+        assert real_elem == orig_elem
+        assert imag_elem == orig_elem
+
+
+@pytest.mark.parametrize("split_tuple", [False, True])
+@pytest.mark.parametrize("elem", scalar_elements+vector_elements)
+def test_set_get_part(mesh, elem, split_tuple):
+    """
+    Test that the real and imaginary parts are set and get correctly from/to real FunctionSpace
+
+    TODO: add tests for tensor_elements
+    """
+    eps = 1e-12
+
+    x, y = fd.SpatialCoordinate(mesh)
+
+    if elem.reference_value_shape() != ():
+        dim = elem.reference_value_shape()[0]
+        expr0 = fd.as_vector([x*i for i in range(dim)])
+        expr1 = fd.as_vector([-y*i for i in range(dim)])
+    else:
+        expr0 = x
+        expr1 = -2*y
+
+    V = fd.FunctionSpace(mesh, elem)
+    W = cpx.FunctionSpace(V)
+
+    u0 = fd.Function(V).project(expr0)
+    u1 = fd.Function(V).project(expr1)
+    ur = fd.Function(V).assign(1)
+    ui = fd.Function(V).assign(1)
+    w = fd.Function(W).assign(0)
+
+    # test with no tuples, both tuples, and mixed
+    u0s = u0.subfunctions if split_tuple else u0
+    u1s = u1
+    urs = ur.subfunctions if split_tuple else ur
+    uis = ui
+    ws = w.subfunctions if split_tuple else w
+
+    # check 0 initialisation
+    cpx.get_real(ws, urs)
+    cpx.get_imag(ws, uis)
+
+    assert fd.norm(ur) < eps
+    assert fd.norm(ui) < eps
+
+    # check real value is set correctly and imag value is unchanged
+    cpx.set_real(ws, u0s)
+
+    cpx.get_real(ws, urs)
+    cpx.get_imag(ws, uis)
+
+    assert fd.errornorm(u0, ur) < eps
+    assert fd.norm(ui) < eps
+
+    # check imag value is set correctly and real value is unchanged
+    cpx.set_imag(ws, u1s)
+
+    cpx.get_real(ws, urs)
+    cpx.get_imag(ws, uis)
+
+    assert fd.errornorm(u0, ur) < eps
+    assert fd.errornorm(u1, ui) < eps
+
+
+def test_mixed_set_get_part(mesh):
+    """
+    Test that the real and imaginary parts are set and get correctly from/to real FunctionSpace
+
+    TODO: add tests for tensor_elements
+    """
+    eps = 1e-12
+
+    x, y = fd.SpatialCoordinate(mesh)
+
+    # set up mixed real space and initialise some functions
+
+    V0 = fd.FunctionSpace(mesh, "BDM", 1)
+    V1 = fd.FunctionSpace(mesh, "DG", 0)
+    V = V0*V1
+
+    u0 = fd.Function(V)
+    u1 = fd.Function(V)
+    ur = fd.Function(V).assign(1)
+    ui = fd.Function(V).assign(1)
+
+    u0.sub(0).project(fd.as_vector([x, 2*x*x]))
+    u1.sub(0).project(fd.as_vector([-3*y, -4*y*y]))
+
+    u0.sub(1).project(5*x)
+    u1.sub(1).project(-6*y)
+
+    # set up complex mixed space
+
+    W = cpx.FunctionSpace(V)
+
+    w = fd.Function(W).assign(0)
+    cpx.get_real(w, ur)
+    cpx.get_imag(w, ui)
+
+    assert fd.norm(ur) < eps
+    assert fd.norm(ui) < eps
+
+    # check real value is set correctly and imag value is unchanged
+    cpx.set_real(w, u0)
+
+    cpx.get_real(w, ur)
+    cpx.get_imag(w, ui)
+
+    assert fd.errornorm(u0, ur) < eps
+    assert fd.norm(ui) < eps
+
+    # check imag value is set correctly and real value is unchanged
+    cpx.set_imag(w, u1)
+
+    cpx.get_real(w, ur)
+    cpx.get_imag(w, ui)
+
+    assert fd.errornorm(u0, ur) < eps
+    assert fd.errornorm(u1, ui) < eps
+
+
+@pytest.mark.parametrize("elem", scalar_elements+vector_elements)
+@pytest.mark.parametrize("z", complex_numbers)
+def test_linear_form(mesh, elem, z):
+    """
+    Test that the linear Form is constructed correctly
+
+    TODO: add tests for tensor_elements
+    """
+    eps = 1e-12
+
+    V = fd.FunctionSpace(mesh, elem)
+    W = cpx.FunctionSpace(V)
+
+    x, y = fd.SpatialCoordinate(mesh)
+
+    if elem.reference_value_shape() != ():
+        vec_expr = [x*x-y, y+x, -y-0.5*x]
+        dim = elem.reference_value_shape()[0]
+        f = fd.as_vector(vec_expr[:dim])
+    else:
+        f = x*x-y
+
+    def L(v):
+        return fd.inner(f, v)*fd.dx
+
+    v = fd.TestFunction(V)
+    rhs = fd.assemble(L(v))
+
+    ur = fd.Function(V)
+    ui = fd.Function(V)
+    w = fd.Function(W)
+
+    w = fd.assemble(cpx.LinearForm(W, z, L))
+
+    cpx.get_real(w, ur)
+    cpx.get_imag(w, ui)
+
+    zr = z.real
+    zi = z.imag
+    assert fd.errornorm(zr*rhs, ur) < eps
+    assert fd.errornorm(zi*rhs, ui) < eps
+
+
+@pytest.mark.parametrize("elem", scalar_elements+vector_elements)
+def test_bilinear_form(mesh, elem):
+    """
+    Test that the bilinear form is constructed correctly
+
+    TODO: add tests for tensor_elements
+    """
+    eps = 1e-12
+
+    # set up the real problem
+    V = fd.FunctionSpace(mesh, elem)
+
+    x, y = fd.SpatialCoordinate(mesh)
+
+    if elem.reference_value_shape() != ():
+        vec_expr = [x*x-y, y+x, -y-0.5*x]
+        dim = elem.reference_value_shape()[0]
+        expr = fd.as_vector(vec_expr[:dim])
+    else:
+        expr = x*x-y
+
+    f = fd.Function(V).interpolate(expr)
+
+    def form_function(u, v):
+        return fd.inner(u, v)*fd.dx
+
+    u = fd.TrialFunction(V)
+    v = fd.TestFunction(V)
+
+    a = form_function(u, v)
+
+    # the real value
+    b = fd.assemble(fd.action(a, f))
+
+    # set up the complex problem
+    W = cpx.FunctionSpace(V)
+
+    g = fd.Function(W)
+
+    cpx.set_real(g, f)
+    f.assign(2*f)
+    cpx.set_imag(g, f)
+
+    # real/imag parts of mat-vec product
+    br = fd.Function(V)
+    bi = fd.Function(V)
+
+    # non-zero only on diagonal blocks: real and imag parts independent
+    zr = 3+0j
+    wr = fd.Function(W)
+
+    K = cpx.BilinearForm(W, zr, form_function)
+    fd.assemble(fd.action(K, g), tensor=wr)
+
+    cpx.get_real(wr, br)
+    cpx.get_imag(wr, bi)
+
+    assert fd.errornorm(3*1*b, br) < eps
+    assert fd.errornorm(3*2*b, bi) < eps
+
+    # non-zero only on off-diagonal blocks: real and imag parts independent
+    zi = 0+4j
+
+    wi = fd.Function(W)
+
+    K = cpx.BilinearForm(W, zi, form_function)
+    fd.assemble(fd.action(K, g), tensor=wi)
+
+    cpx.get_real(wi, br)
+    cpx.get_imag(wi, bi)
+
+    assert fd.errornorm(-4*2*b, br) < 1e-12
+    assert fd.errornorm(4*1*b, bi) < 1e-12
+
+    # non-zero in all blocks:
+    z = zr + zi
+
+    wz = fd.Function(W)
+
+    K = cpx.BilinearForm(W, z, form_function)
+    fd.assemble(fd.action(K, g), tensor=wz)
+
+    cpx.get_real(wz, br)
+    cpx.get_imag(wz, bi)
+
+    # mat-vec multiplication should be linear
+    br_check = fd.Function(V)
+    bi_check = fd.Function(V)
+
+    wz.assign(wr + wi)
+
+    cpx.get_real(wz, br_check)
+    cpx.get_imag(wz, bi_check)
+
+    assert fd.errornorm(br_check, br) < 1e-12
+    assert fd.errornorm(bi_check, bi) < 1e-12
+
+
+@pytest.mark.parametrize("bc_type", ["nobc", "dirichletbc"])
+def test_linear_solve(mesh, bc_type):
+    """
+    Test that the bilinear form is constructed correctly
+
+    TODO: add tests for tensor_elements
+    """
+    from math import pi
+
+    eps = 1e-12
+
+    # set up the real problem
+    V = fd.FunctionSpace(mesh, "CG", 1)
+
+    x, y = fd.SpatialCoordinate(mesh)
+
+    def form_function(u, v):
+        return (fd.inner(u, v) + fd.dot(fd.grad(u), fd.grad(v)))*fd.dx
+
+    f = (2*pi**2)*fd.sin(pi*x)*fd.sin(pi*y)
+
+    def rhs(v):
+        return fd.inner(f, v)*fd.dx
+
+    # the real solution
+    u = fd.TrialFunction(V)
+    v = fd.TestFunction(V)
+    A = form_function(u, v)
+    L = rhs(v)
+
+    if bc_type == "nobc":
+        bcs = []
+    elif bc_type == "dirichletbc":
+        bcs = [fd.DirichletBC(V, 0, 1)]
+    else:
+        raise ValueError(f"Unrecognised boundary condition type: {bc_type}")
+
+    ureal = fd.Function(V)
+    fd.solve(A == L, ureal, bcs=bcs)
+
+    # set up the complex problem
+    W = cpx.FunctionSpace(V)
+
+    cpx_bcs = []
+    for bc in bcs:
+        cpx_bcs.extend([*cpx.DirichletBC(W, V, bc)])
+
+    # A non-zero only on diagonal blocks: real and imag parts independent
+    zr = 3+0j
+    zl = 1+2j
+
+    A = cpx.BilinearForm(W, zr, form_function)
+    L = cpx.LinearForm(W, zl, rhs)
+
+    wr = fd.Function(W)
+
+    fd.solve(A == L, wr, bcs=cpx_bcs)
+
+    wcheckr = fd.Function(V)
+    wchecki = fd.Function(V)
+
+    cpx.get_real(wr, wcheckr)
+    cpx.get_imag(wr, wchecki)
+
+    assert fd.errornorm(1*ureal/3, wcheckr) < eps
+    assert fd.errornorm(2*ureal/3, wchecki) < eps
+
+    # non-zero on all blocks but imag part of rhs is zero
+    zi = 2+4j
+
+    A = cpx.BilinearForm(W, zi, form_function)
+    L = cpx.LinearForm(W, 1, rhs)
+
+    wi = fd.Function(W)
+
+    fd.solve(A == L, wi, bcs=cpx_bcs)
+
+    cpx.get_real(wi, wcheckr)
+    cpx.get_imag(wi, wchecki)
+
+    # eliminate imaginary part to check real part
+    assert fd.errornorm(2*ureal/(2*2+4*4), wcheckr) < 1e-12
+
+    # back substitute real part to check imaginary part
+    g = 0.25*(2*fd.action(form_function(u, v), wcheckr) - rhs(v))
+    a = form_function(u, v)
+
+    ui = fd.Function(V)
+    fd.solve(a == g, ui, bcs=bcs)
+
+    assert fd.errornorm(ui, wchecki)
+
+
+@pytest.mark.parametrize("bc_type", ["nobc", "dirichletbc"])
+def test_mixed_linear_solve(mesh, bc_type):
+    """
+    Test that the bilinear form is constructed correctly
+
+    TODO: add tests for tensor_elements
+    """
+    eps = 1e-12
+
+    # set up the real problem
+    V0 = fd.FunctionSpace(mesh, "BDM", 1)
+    V1 = fd.FunctionSpace(mesh, "DG", 0)
+    V = V0*V1
+
+    x, y = fd.SpatialCoordinate(mesh)
+
+    def form_function(sigma, u, tau, v):
+        return (fd.dot(sigma, tau) + fd.div(tau)*u + fd.div(sigma)*v)*fd.dx
+
+    def rhs(tau, v):
+        f = 10*fd.exp(-(pow(x - 0.5, 2) + pow(y - 0.5, 2)) / 0.02)
+        return -fd.inner(f, v)*fd.dx
+
+    if bc_type == "nobc":
+        bcs = []
+    elif bc_type == "dirichletbc":
+        bcs = [
+            fd.DirichletBC(V.sub(1), 0, 3),
+            fd.DirichletBC(V.sub(1), 0, 4)
+        ]
+    else:
+        raise ValueError(f"Unrecognised boundary condition type: {bc_type}")
+
+    # the real solution
+    u = fd.TrialFunctions(V)
+    v = fd.TestFunctions(V)
+    A = form_function(*u, *v)
+    L = rhs(*v)
+
+    ureal = fd.Function(V)
+    fd.solve(A == L, ureal, bcs=bcs)
+
+    # set up the complex problem
+    W = cpx.FunctionSpace(V)
+
+    cpx_bcs = []
+    for bc in bcs:
+        cpx_bcs.extend([*cpx.DirichletBC(W, V, bc)])
+
+    # A non-zero only on diagonal blocks: real and imag parts independent
+    zr = 3+0j
+    zl = 1+2j
+
+    A = cpx.BilinearForm(W, zr, form_function)
+    L = cpx.LinearForm(W, zl, rhs)
+
+    wr = fd.Function(W)
+
+    fd.solve(A == L, wr, bcs=cpx_bcs)
+
+    wcheckr = fd.Function(V)
+    wchecki = fd.Function(V)
+
+    cpx.get_real(wr, wcheckr)
+    cpx.get_imag(wr, wchecki)
+
+    assert fd.errornorm(1*ureal/3, wcheckr) < eps
+    assert fd.errornorm(2*ureal/3, wchecki) < eps
+
+    # non-zero on all blocks but imag part of rhs is zero
+    zi = 2+4j
+
+    A = cpx.BilinearForm(W, zi, form_function)
+    L = cpx.LinearForm(W, 1, rhs)
+
+    wi = fd.Function(W)
+
+    fd.solve(A == L, wi, bcs=cpx_bcs)
+
+    cpx.get_real(wi, wcheckr)
+    cpx.get_imag(wi, wchecki)
+
+    # eliminate imaginary part to check real part
+    assert fd.errornorm(2*ureal/(2*2+4*4), wcheckr) < 1e-12
+
+    # back substitute real part to check imaginary part
+    g = 0.25*(2*fd.action(form_function(*u, *v), wcheckr) - rhs(*v))
+    a = form_function(*u, *v)
+
+    ui = fd.Function(V)
+    fd.solve(a == g, ui, bcs=bcs)
+
+    assert fd.errornorm(ui, wchecki)
+
+
+def test_derivative_solve(mesh):
+    """
+    Test that the bilinear form is constructed correctly
+
+    TODO: add tests for tensor_elements
+    """
+    from math import pi
+
+    eps = 1e-12
+
+    # set up the real problem
+    V = fd.FunctionSpace(mesh, "CG", 1)
+
+    x, y = fd.SpatialCoordinate(mesh)
+
+    mu = fd.Constant(0.05)
+
+    def form_function(u, v):
+        return (fd.inner(u, v) + (1 + mu*fd.inner(u, u))*fd.dot(fd.grad(u), fd.grad(v)))*fd.dx
+
+    f = (1 + 8*pi*pi)*fd.cos(2*pi*x)*fd.cos(2*pi*y)
+
+    def rhs(v):
+        return fd.inner(f, v)*fd.dx
+
+    init_expr = fd.cos(2*pi*x)*fd.cos(2*pi*y)
+
+    # the real solution
+    u = fd.Function(V).project(init_expr)
+    v = fd.TestFunction(V)
+    F = form_function(u, v)
+    A = fd.derivative(F, u)
+    L = rhs(v)
+
+    ureal = fd.Function(V)
+    fd.solve(A == L, ureal)
+
+    # set up the complex problem
+    W = cpx.FunctionSpace(V)
+
+    # linearise around "u"
+    u0 = fd.Function(W)
+    cpx.set_real(u0, u)
+    cpx.set_imag(u0, u)
+
+    # A non-zero only on diagonal blocks: real and imag parts independent
+    zr = 3+0j
+    zl = 1+2j
+
+    A = cpx.derivative(zr, form_function, u0)
+    L = cpx.LinearForm(W, zl, rhs)
+
+    wr = fd.Function(W)
+
+    fd.solve(A == L, wr)
+
+    wcheckr = fd.Function(V)
+    wchecki = fd.Function(V)
+
+    cpx.get_real(wr, wcheckr)
+    cpx.get_imag(wr, wchecki)
+
+    assert fd.errornorm(1*ureal/3, wcheckr) < eps
+    assert fd.errornorm(2*ureal/3, wchecki) < eps
+
+    # non-zero on all blocks but imag part of rhs is zero
+    zi = 2+4j
+
+    A = cpx.derivative(zi, form_function, u0)
+    L = cpx.LinearForm(W, 1, rhs)
+
+    wi = fd.Function(W)
+
+    fd.solve(A == L, wi)
+
+    cpx.get_real(wi, wcheckr)
+    cpx.get_imag(wi, wchecki)
+
+    # eliminate imaginary part to check real part
+    assert fd.errornorm(2*ureal/(2*2+4*4), wcheckr) < 1e-12
+
+    # back substitute real part to check imaginary part
+    ut = fd.Function(V).project(init_expr)
+    F = form_function(ut, v)
+    A = fd.derivative(F, ut)
+    g = 0.25*(2*fd.action(A, wcheckr) - rhs(v))
+
+    ui = fd.Function(V)
+    fd.solve(A == g, ui)
+
+    assert fd.errornorm(ui, wchecki)

--- a/tests/test_complex_proxy/test_complex_vector.py
+++ b/tests/test_complex_proxy/test_complex_vector.py
@@ -1,0 +1,665 @@
+
+import firedrake as fd
+import asQ.complex_proxy.vector as cpx
+
+import pytest
+
+
+cell = fd.Cell('triangle')
+
+scalar_elements = [
+    pytest.param(fd.FiniteElement("CG", cell, 1), id="CG1"),
+    pytest.param(fd.FiniteElement("BDM", cell, 2), id="BDM1")
+]
+
+vector_elements = [
+    pytest.param(fd.VectorElement("DG", cell, 1), id="VectorDG1"),
+    pytest.param(fd.VectorElement("DG", cell, 1, dim=3), id="VectorDG1_3D")
+]
+
+tensor_elements = [
+    pytest.param(fd.TensorElement("Lagrange", cell, 1), id="TensorL1"),
+    pytest.param(fd.TensorElement("Lagrange", cell, 1, shape=(2, 3, 4)), id="TensorL1_234D")
+]
+
+elements = scalar_elements + vector_elements + tensor_elements
+
+
+complex_numbers = [2+0j, 0+3j, 3+2j]
+
+
+@pytest.fixture
+def nx():
+    return 10
+
+
+@pytest.fixture
+def mesh(nx):
+    return fd.UnitSquareMesh(nx, nx)
+
+
+@pytest.fixture
+def mixed_element():
+    return fd.MixedElement([param.values[0] for param in elements])
+
+
+@pytest.mark.parametrize("elem", scalar_elements)
+def test_finite_element(elem):
+    """
+    Test that the complex proxy FiniteElement is constructed correctly from a real FiniteElement.
+    """
+    celem = cpx.FiniteElement(elem)
+
+    assert celem.num_sub_elements() == 2
+
+    for ce in celem.sub_elements():
+        assert ce == elem
+
+
+@pytest.mark.parametrize("elem", vector_elements)
+def test_vector_element(elem):
+    """
+    Test that the complex proxy FiniteElement is constructed correctly from a real VectorElement.
+    """
+    celem = cpx.FiniteElement(elem)
+
+    assert celem.num_sub_elements() == 2*elem.num_sub_elements()
+
+    assert celem._shape == (2, elem.num_sub_elements())
+
+    for ce in celem.sub_elements():
+        assert ce == elem.sub_elements()[0]
+
+
+@pytest.mark.parametrize("elem", tensor_elements)
+def test_tensor_element(elem):
+    """
+    Test that the complex proxy FiniteElement is constructed correctly from a real TensorElement.
+    """
+    celem = cpx.FiniteElement(elem)
+
+    assert celem.num_sub_elements() == 2*elem.num_sub_elements()
+
+    assert celem._shape == (2,) + elem._shape
+
+    for ce in celem.sub_elements():
+        assert ce == elem.sub_elements()[0]
+
+
+def test_mixed_element(mixed_element):
+    """
+    Test that the complex proxy FiniteElement is constructed correctly from a real MixedElement.
+    """
+
+    celem = cpx.FiniteElement(mixed_element)
+
+    assert celem.num_sub_elements() == mixed_element.num_sub_elements()
+
+    for csub, msub in zip(celem.sub_elements(), mixed_element.sub_elements()):
+        assert csub == cpx.FiniteElement(msub)
+
+
+@pytest.mark.parametrize("elem", elements)
+def test_function_space(mesh, elem):
+    """
+    Test that the proxy complex FunctionSpace is correctly constructed for a scalar real FunctionSpace
+    """
+    V = fd.FunctionSpace(mesh, elem)
+    W = cpx.FunctionSpace(V)
+
+    assert W.ufl_element() == cpx.FiniteElement(elem)
+
+
+def test_mixed_function_space(mesh, mixed_element):
+    """
+    Test that the proxy complex FunctionSpace is correctly constructed for a mixed real FunctionSpace
+    """
+
+    V = fd.FunctionSpace(mesh, mixed_element)
+    W = cpx.FunctionSpace(V)
+
+    assert len(W.subfunctions) == len(V.subfunctions)
+
+    for wcpt, vcpt in zip(W.subfunctions, V.subfunctions):
+        assert wcpt == cpx.FunctionSpace(vcpt)
+
+
+@pytest.mark.parametrize("split_tuple", [False, True])
+@pytest.mark.parametrize("elem", scalar_elements)
+def test_set_get_part(mesh, elem, split_tuple):
+    """
+    Test that the real and imaginary parts are set and get correctly from/to real FunctionSpace
+
+    TODO: add tests for vector_elements and tensor_elements
+    """
+    eps = 1e-12
+
+    x, y = fd.SpatialCoordinate(mesh)
+
+    if elem.reference_value_shape() != ():
+        dim = elem.reference_value_shape()[0]
+        expr0 = fd.as_vector([x*i for i in range(dim)])
+        expr1 = fd.as_vector([-y*i for i in range(dim)])
+    else:
+        expr0 = x
+        expr1 = -2*y
+
+    V = fd.FunctionSpace(mesh, elem)
+    W = cpx.FunctionSpace(V)
+
+    u0 = fd.Function(V).project(expr0)
+    u1 = fd.Function(V).project(expr1)
+    ur = fd.Function(V).assign(1)
+    ui = fd.Function(V).assign(1)
+    w = fd.Function(W).assign(0)
+
+    # test with no tuples, both tuples, and mixed
+    u0s = u0.subfunctions if split_tuple else u0
+    u1s = u1
+    urs = ur.subfunctions if split_tuple else ur
+    uis = ui
+    ws = w.subfunctions if split_tuple else w
+
+    # check 0 initialisation
+    cpx.get_real(ws, urs)
+    cpx.get_imag(ws, uis)
+
+    assert fd.norm(ur) < eps
+    assert fd.norm(ui) < eps
+
+    # check real value is set correctly and imag value is unchanged
+    cpx.set_real(ws, u0s)
+
+    cpx.get_real(ws, urs)
+    cpx.get_imag(ws, uis)
+
+    assert fd.errornorm(u0, ur) < eps
+    assert fd.norm(ui) < eps
+
+    # check imag value is set correctly and real value is unchanged
+    cpx.set_imag(ws, u1s)
+
+    cpx.get_real(ws, urs)
+    cpx.get_imag(ws, uis)
+
+    assert fd.errornorm(u0, ur) < eps
+    assert fd.errornorm(u1, ui) < eps
+
+
+def test_mixed_set_get_part(mesh):
+    """
+    Test that the real and imaginary parts are set and get correctly from/to real FunctionSpace
+
+    TODO: add tests for tensor_elements
+    """
+    eps = 1e-12
+
+    x, y = fd.SpatialCoordinate(mesh)
+
+    # set up mixed real space and initialise some functions
+
+    V0 = fd.FunctionSpace(mesh, "BDM", 1)
+    V1 = fd.FunctionSpace(mesh, "DG", 0)
+    V = V0*V1
+
+    u0 = fd.Function(V)
+    u1 = fd.Function(V)
+    ur = fd.Function(V).assign(1)
+    ui = fd.Function(V).assign(1)
+
+    u0.sub(0).project(fd.as_vector([x, 2*x*x]))
+    u1.sub(0).project(fd.as_vector([-3*y, -4*y*y]))
+
+    u0.sub(1).project(5*x)
+    u1.sub(1).project(-6*y)
+
+    # set up complex mixed space
+
+    W = cpx.FunctionSpace(V)
+
+    w = fd.Function(W).assign(0)
+    cpx.get_real(w, ur)
+    cpx.get_imag(w, ui)
+
+    assert fd.norm(ur) < eps
+    assert fd.norm(ui) < eps
+
+    # check real value is set correctly and imag value is unchanged
+    cpx.set_real(w, u0)
+
+    cpx.get_real(w, ur)
+    cpx.get_imag(w, ui)
+
+    assert fd.errornorm(u0, ur) < eps
+    assert fd.norm(ui) < eps
+
+    # check imag value is set correctly and real value is unchanged
+    cpx.set_imag(w, u1)
+
+    cpx.get_real(w, ur)
+    cpx.get_imag(w, ui)
+
+    assert fd.errornorm(u0, ur) < eps
+    assert fd.errornorm(u1, ui) < eps
+
+
+@pytest.mark.parametrize("elem", scalar_elements[:1])
+@pytest.mark.parametrize("z", complex_numbers)
+def test_linear_form(mesh, elem, z):
+    """
+    Test that the linear Form is constructed correctly
+
+    TODO: add tests for tensor_elements
+    """
+    eps = 1e-12
+
+    V = fd.FunctionSpace(mesh, elem)
+    W = cpx.FunctionSpace(V)
+
+    x, y = fd.SpatialCoordinate(mesh)
+
+    if elem.reference_value_shape() != ():
+        vec_expr = [x*x-y, y+x, -y-0.5*x]
+        dim = elem.reference_value_shape()[0]
+        f = fd.as_vector(vec_expr[:dim])
+    else:
+        f = x*x-y
+
+    def L(v):
+        return fd.inner(f, v)*fd.dx
+
+    v = fd.TestFunction(V)
+    rhs = fd.assemble(L(v))
+
+    ur = fd.Function(V)
+    ui = fd.Function(V)
+    w = fd.Function(W)
+
+    w = fd.assemble(cpx.LinearForm(W, z, L))
+
+    cpx.get_real(w, ur)
+    cpx.get_imag(w, ui)
+
+    zr = z.real
+    zi = z.imag
+    assert fd.errornorm(zr*rhs, ur) < eps
+    assert fd.errornorm(zi*rhs, ui) < eps
+
+
+@pytest.mark.parametrize("elem", scalar_elements[:1])
+def test_bilinear_form(mesh, elem):
+    """
+    Test that the bilinear form is constructed correctly
+
+    TODO: add tests for tensor_elements
+    """
+    eps = 1e-12
+
+    # set up the real problem
+    V = fd.FunctionSpace(mesh, elem)
+
+    x, y = fd.SpatialCoordinate(mesh)
+
+    if elem.reference_value_shape() != ():
+        vec_expr = [x*x-y, y+x, -y-0.5*x]
+        dim = elem.reference_value_shape()[0]
+        expr = fd.as_vector(vec_expr[:dim])
+    else:
+        expr = x*x-y
+
+    f = fd.Function(V).interpolate(expr)
+
+    def form_function(u, v):
+        return fd.inner(u, v)*fd.dx
+
+    u = fd.TrialFunction(V)
+    v = fd.TestFunction(V)
+
+    a = form_function(u, v)
+
+    # the real value
+    b = fd.assemble(fd.action(a, f))
+
+    # set up the complex problem
+    W = cpx.FunctionSpace(V)
+
+    g = fd.Function(W)
+
+    cpx.set_real(g, f)
+    f.assign(2*f)
+    cpx.set_imag(g, f)
+
+    # real/imag parts of mat-vec product
+    br = fd.Function(V)
+    bi = fd.Function(V)
+
+    # non-zero only on diagonal blocks: real and imag parts independent
+    zr = 3+0j
+    wr = fd.Function(W)
+
+    K = cpx.BilinearForm(W, zr, form_function)
+    fd.assemble(fd.action(K, g), tensor=wr)
+
+    cpx.get_real(wr, br)
+    cpx.get_imag(wr, bi)
+
+    assert fd.errornorm(3*1*b, br) < eps
+    assert fd.errornorm(3*2*b, bi) < eps
+
+    # non-zero only on off-diagonal blocks: real and imag parts independent
+    zi = 0+4j
+
+    wi = fd.Function(W)
+
+    K = cpx.BilinearForm(W, zi, form_function)
+    fd.assemble(fd.action(K, g), tensor=wi)
+
+    cpx.get_real(wi, br)
+    cpx.get_imag(wi, bi)
+
+    assert fd.errornorm(-4*2*b, br) < 1e-12
+    assert fd.errornorm(4*1*b, bi) < 1e-12
+
+    # non-zero in all blocks:
+    z = zr + zi
+
+    wz = fd.Function(W)
+
+    K = cpx.BilinearForm(W, z, form_function)
+    fd.assemble(fd.action(K, g), tensor=wz)
+
+    cpx.get_real(wz, br)
+    cpx.get_imag(wz, bi)
+
+    # mat-vec multiplication should be linear
+    br_check = fd.Function(V)
+    bi_check = fd.Function(V)
+
+    wz.assign(wr + wi)
+
+    cpx.get_real(wz, br_check)
+    cpx.get_imag(wz, bi_check)
+
+    assert fd.errornorm(br_check, br) < 1e-12
+    assert fd.errornorm(bi_check, bi) < 1e-12
+
+
+@pytest.mark.parametrize("bc_type", ["nobc", "dirichletbc"])
+def test_linear_solve(mesh, bc_type):
+    """
+    Test that the bilinear form is constructed correctly
+
+    TODO: add tests for tensor_elements
+    """
+    from math import pi
+
+    eps = 1e-12
+
+    # set up the real problem
+    V = fd.FunctionSpace(mesh, "CG", 1)
+
+    x, y = fd.SpatialCoordinate(mesh)
+
+    def form_function(u, v):
+        return (fd.inner(u, v) + fd.dot(fd.grad(u), fd.grad(v)))*fd.dx
+
+    f = (2*pi**2)*fd.sin(pi*x)*fd.sin(pi*y)
+
+    def rhs(v):
+        return fd.inner(f, v)*fd.dx
+
+    # the real solution
+    u = fd.TrialFunction(V)
+    v = fd.TestFunction(V)
+    A = form_function(u, v)
+    L = rhs(v)
+
+    if bc_type == "nobc":
+        bcs = []
+    elif bc_type == "dirichletbc":
+        bcs = [fd.DirichletBC(V, 0, 1)]
+    else:
+        raise ValueError(f"Unrecognised boundary condition type: {bc_type}")
+
+    ureal = fd.Function(V)
+    fd.solve(A == L, ureal, bcs=bcs)
+
+    # set up the complex problem
+    W = cpx.FunctionSpace(V)
+
+    cpx_bcs = []
+    for bc in bcs:
+        cpx_bcs.extend([*cpx.DirichletBC(W, V, bc)])
+
+    # A non-zero only on diagonal blocks: real and imag parts independent
+    zr = 3+0j
+    zl = 1+2j
+
+    A = cpx.BilinearForm(W, zr, form_function)
+    L = cpx.LinearForm(W, zl, rhs)
+
+    wr = fd.Function(W)
+
+    fd.solve(A == L, wr, bcs=cpx_bcs)
+
+    wcheckr = fd.Function(V)
+    wchecki = fd.Function(V)
+
+    cpx.get_real(wr, wcheckr)
+    cpx.get_imag(wr, wchecki)
+
+    assert fd.errornorm(1*ureal/3, wcheckr) < eps
+    assert fd.errornorm(2*ureal/3, wchecki) < eps
+
+    # non-zero on all blocks but imag part of rhs is zero
+    zi = 2+4j
+
+    A = cpx.BilinearForm(W, zi, form_function)
+    L = cpx.LinearForm(W, 1, rhs)
+
+    wi = fd.Function(W)
+
+    fd.solve(A == L, wi, bcs=cpx_bcs)
+
+    cpx.get_real(wi, wcheckr)
+    cpx.get_imag(wi, wchecki)
+
+    # eliminate imaginary part to check real part
+    assert fd.errornorm(2*ureal/(2*2+4*4), wcheckr) < 1e-12
+
+    # back substitute real part to check imaginary part
+    g = 0.25*(2*fd.action(form_function(u, v), wcheckr) - rhs(v))
+    a = form_function(u, v)
+
+    ui = fd.Function(V)
+    fd.solve(a == g, ui, bcs=bcs)
+
+    assert fd.errornorm(ui, wchecki)
+
+
+@pytest.mark.parametrize("bc_type", ["nobc", "dirichletbc"])
+def test_mixed_linear_solve(mesh, bc_type):
+    """
+    Test that the bilinear form is constructed correctly
+
+    TODO: add tests for tensor_elements
+    """
+    eps = 1e-12
+
+    # set up the real problem
+    V0 = fd.FunctionSpace(mesh, "BDM", 1)
+    V1 = fd.FunctionSpace(mesh, "DG", 0)
+    V = V0*V1
+
+    x, y = fd.SpatialCoordinate(mesh)
+
+    def form_function(sigma, u, tau, v):
+        return (fd.dot(sigma, tau) + fd.div(tau)*u + fd.div(sigma)*v)*fd.dx
+
+    def rhs(tau, v):
+        f = 10*fd.exp(-(pow(x - 0.5, 2) + pow(y - 0.5, 2)) / 0.02)
+        return -fd.inner(f, v)*fd.dx
+
+    if bc_type == "nobc":
+        bcs = []
+    elif bc_type == "dirichletbc":
+        bcs = [
+            fd.DirichletBC(V.sub(1), 0, 3),
+            fd.DirichletBC(V.sub(1), 0, 4)
+        ]
+    else:
+        raise ValueError(f"Unrecognised boundary condition type: {bc_type}")
+
+    # the real solution
+    u = fd.TrialFunctions(V)
+    v = fd.TestFunctions(V)
+    A = form_function(*u, *v)
+    L = rhs(*v)
+
+    ureal = fd.Function(V)
+    fd.solve(A == L, ureal, bcs=bcs)
+
+    # set up the complex problem
+    W = cpx.FunctionSpace(V)
+
+    cpx_bcs = []
+    for bc in bcs:
+        cpx_bcs.extend([*cpx.DirichletBC(W, V, bc)])
+
+    # A non-zero only on diagonal blocks: real and imag parts independent
+    zr = 3+0j
+    zl = 1+2j
+
+    A = cpx.BilinearForm(W, zr, form_function)
+    L = cpx.LinearForm(W, zl, rhs)
+
+    wr = fd.Function(W)
+
+    fd.solve(A == L, wr, bcs=cpx_bcs)
+
+    wcheckr = fd.Function(V)
+    wchecki = fd.Function(V)
+
+    cpx.get_real(wr, wcheckr)
+    cpx.get_imag(wr, wchecki)
+
+    assert fd.errornorm(1*ureal/3, wcheckr) < eps
+    assert fd.errornorm(2*ureal/3, wchecki) < eps
+
+    # non-zero on all blocks but imag part of rhs is zero
+    zi = 2+4j
+
+    A = cpx.BilinearForm(W, zi, form_function)
+    L = cpx.LinearForm(W, 1, rhs)
+
+    wi = fd.Function(W)
+
+    fd.solve(A == L, wi, bcs=cpx_bcs)
+
+    cpx.get_real(wi, wcheckr)
+    cpx.get_imag(wi, wchecki)
+
+    # eliminate imaginary part to check real part
+    assert fd.errornorm(2*ureal/(2*2+4*4), wcheckr) < 1e-12
+
+    # back substitute real part to check imaginary part
+    g = 0.25*(2*fd.action(form_function(*u, *v), wcheckr) - rhs(*v))
+    a = form_function(*u, *v)
+
+    ui = fd.Function(V)
+    fd.solve(a == g, ui, bcs=bcs)
+
+    assert fd.errornorm(ui, wchecki)
+
+
+def test_derivative_solve(mesh):
+    """
+    Test that the bilinear form is constructed correctly
+
+    TODO: add tests for tensor_elements
+    """
+    from math import pi
+
+    eps = 1e-12
+
+    # set up the real problem
+    V = fd.FunctionSpace(mesh, "CG", 1)
+
+    x, y = fd.SpatialCoordinate(mesh)
+
+    mu = fd.Constant(0.05)
+
+    def form_function(u, v):
+        return (fd.inner(u, v) + (1 + mu*fd.inner(u, u))*fd.dot(fd.grad(u), fd.grad(v)))*fd.dx
+
+    f = (1 + 8*pi*pi)*fd.cos(2*pi*x)*fd.cos(2*pi*y)
+
+    def rhs(v):
+        return fd.inner(f, v)*fd.dx
+
+    init_expr = fd.cos(2*pi*x)*fd.cos(2*pi*y)
+
+    # the real solution
+    u = fd.Function(V).project(init_expr)
+    v = fd.TestFunction(V)
+    F = form_function(u, v)
+    A = fd.derivative(F, u)
+    L = rhs(v)
+
+    ureal = fd.Function(V)
+    fd.solve(A == L, ureal)
+
+    # set up the complex problem
+    W = cpx.FunctionSpace(V)
+
+    # linearise around "u"
+    u0 = fd.Function(W)
+    cpx.set_real(u0, u)
+    cpx.set_imag(u0, u)
+
+    # A non-zero only on diagonal blocks: real and imag parts independent
+    zr = 3+0j
+    zl = 1+2j
+
+    A = cpx.derivative(zr, form_function, u0)
+    L = cpx.LinearForm(W, zl, rhs)
+
+    wr = fd.Function(W)
+
+    fd.solve(A == L, wr)
+
+    wcheckr = fd.Function(V)
+    wchecki = fd.Function(V)
+
+    cpx.get_real(wr, wcheckr)
+    cpx.get_imag(wr, wchecki)
+
+    assert fd.errornorm(1*ureal/3, wcheckr) < eps
+    assert fd.errornorm(2*ureal/3, wchecki) < eps
+
+    # non-zero on all blocks but imag part of rhs is zero
+    zi = 2+4j
+
+    A = cpx.derivative(zi, form_function, u0)
+    L = cpx.LinearForm(W, 1, rhs)
+
+    wi = fd.Function(W)
+
+    fd.solve(A == L, wi)
+
+    cpx.get_real(wi, wcheckr)
+    cpx.get_imag(wi, wchecki)
+
+    # eliminate imaginary part to check real part
+    assert fd.errornorm(2*ureal/(2*2+4*4), wcheckr) < 1e-12
+
+    # back substitute real part to check imaginary part
+    ut = fd.Function(V).project(init_expr)
+    F = form_function(ut, v)
+    A = fd.derivative(F, ut)
+    g = 0.25*(2*fd.action(A, wcheckr) - rhs(v))
+
+    ui = fd.Function(V)
+    fd.solve(A == g, ui)
+
+    assert fd.errornorm(ui, wchecki)


### PR DESCRIPTION
This PR tidies up the `DiagFFTPC` a bit by factoring out the logic for dealing with the complex-valued space in the block diagonalised system.

This uses the complex-proxy module here: [https://github.com/JHopeCollins/complex-proxy](https://github.com/JHopeCollins/complex-proxy)
I'm not sure where this module should live going forward. We use it here, but it doesn't depend on anything in asQ, and could also be used for e.g. REXI schemes so it probably makes sense to keep it somewhat independent.

The complex-proxy module includes creating the proxy `FunctionSpace`, accessing the real/imaginary components of `Functions` from the proxy space, creating `Forms` on the proxy space given a way of creating forms on the "real" space, creating `DirichletBCs` on the proxy space from `DirichletBCs` on the "real" space etc.