### PR TITLE
Alternative linearisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *.dat
 *.out
 .coverage*
+**/metrics/*

--- a/asQ/diag_preconditioner.py
+++ b/asQ/diag_preconditioner.py
@@ -64,7 +64,7 @@ class DiagFFTPC(object):
         self.jac_average = PETSc.Options().getString(
             f"{prefix}{self.prefix}jac_average", default='window')
 
-        valid_jac_averages = ['window', 'slice']
+        valid_jac_averages = ['window', 'slice', 'linear']
 
         if self.jac_average not in valid_jac_averages:
             raise ValueError("diagfft_jac_average must be one of "+" or ".join(valid_jac_averages))
@@ -114,7 +114,7 @@ class DiagFFTPC(object):
                                                             bc, 0*bc.function_arg)))
 
         # function to do global reduction into for average block jacobian
-        if self.jac_average == 'window':
+        if self.jac_average in ('window', 'slice'):
             self.ureduce = fd.Function(self.blockV)
             self.uwrk = fd.Function(self.blockV)
 
@@ -278,6 +278,10 @@ class DiagFFTPC(object):
         an operator that is block diagonal in the 2x2 system coupling
         real and imaginary parts.
         '''
+        if self.jac_average == 'linear':
+            PETSc.Sys.Print("No time average")
+            return
+
         self.ureduce.assign(0)
 
         urs = self.ureduce.subfunctions

--- a/asQ/diag_preconditioner.py
+++ b/asQ/diag_preconditioner.py
@@ -64,7 +64,7 @@ class DiagFFTPC(object):
         self.jac_average = PETSc.Options().getString(
             f"{prefix}{self.prefix}jac_average", default='window')
 
-        valid_jac_averages = ['window', 'slice', 'linear']
+        valid_jac_averages = ['window', 'slice', 'linear', 'initial']
 
         if self.jac_average not in valid_jac_averages:
             raise ValueError("diagfft_jac_average must be one of "+" or ".join(valid_jac_averages))
@@ -280,6 +280,10 @@ class DiagFFTPC(object):
         '''
         if self.jac_average == 'linear':
             PETSc.Sys.Print("No time average")
+            return
+        elif self.jac_average == 'initial':
+            cpx.set_real(self.u0, self.aaos.initial_condition)
+            cpx.set_imag(self.u0, self.aaos.initial_condition)
             return
 
         self.ureduce.assign(0)

--- a/asQ/paradiag.py
+++ b/asQ/paradiag.py
@@ -42,6 +42,7 @@ class paradiag(object):
                  form_function, form_mass, w0, dt, theta,
                  alpha, time_partition, bcs=[],
                  solver_parameters={},
+                 reference_state=None,
                  circ="picard",
                  tol=1.0e-6, maxits=10,
                  ctx={}, block_ctx={}, block_mat_type="aij"):
@@ -49,36 +50,38 @@ class paradiag(object):
 
         :arg ensemble: the ensemble communicator
         :arg form_function: a function that returns a linear form
-        on w0.function_space() providing f(w) for the ODE w_t + f(w) = 0.
+            on w0.function_space() providing f(w) for the ODE w_t + f(w) = 0.
         :arg form_mass: a function that returns a linear form
-        on W providing the mass operator for the time derivative.
+            on W providing the mass operator for the time derivative.
         :arg w0: a Function from W containing the initial data
         :arg dt: float, the timestep size.
         :arg theta: float, implicit timestepping parameter
         :arg alpha: float, circulant matrix parameter
         :arg time_partition: a list of integers, the number of timesteps
-        assigned to each rank
+            assigned to each rank
         :arg bcs: a list of DirichletBC boundary conditions on W
         :arg solver_parameters: options dictionary for nonlinear solver
+        :arg reference_state: a Function in W to use as a reference state
+            e.g. in DiagFFTPC
         :arg circ: a string describing the option on where to use the
-        alpha-circulant modification. "picard" - do a nonlinear wave
-        form relaxation method. "quasi" - do a modified Newton
-        method with alpha-circulant modification added to the
-        Jacobian. To make the alpha circulant modification only in the
-        preconditioner, simply set ksp_type:preonly in the solve options.
+            alpha-circulant modification. "picard" - do a nonlinear wave
+            form relaxation method. "quasi" - do a modified Newton
+            method with alpha-circulant modification added to the
+            Jacobian. To make the alpha circulant modification only in the
+            preconditioner, simply set ksp_type:preonly in the solve options.
         :arg tol: float, the tolerance for the relaxation method (if used)
         :arg maxits: integer, the maximum number of iterations for the
-        relaxation method, if used.
+            relaxation method, if used.
         :arg ctx: application context for solvers.
         :arg block_ctx: non-petsc context for solvers.
         :arg block_mat_type: set the type of the diagonal block systems.
-        Default is aij.
+            Default is aij.
         """
 
         self.aaos = AllAtOnceSystem(ensemble, time_partition,
                                     dt, theta,
                                     form_mass, form_function,
-                                    w0, bcs,
+                                    w0, bcs, reference_state,
                                     circ, alpha)
 
         self.ensemble = ensemble

--- a/asQ/paradiag.py
+++ b/asQ/paradiag.py
@@ -114,11 +114,11 @@ class paradiag(object):
                 appctx["paradiag"] = self
                 solver_parameters["diagfft_context"] = "asQ.paradiag.get_context"
         self.solver_parameters = solver_parameters
-        flat_solver_parameters = flatten_parameters(solver_parameters)
+        self.flat_solver_parameters = flatten_parameters(solver_parameters)
 
         # set up the snes
         self.snes = PETSc.SNES().create(comm=ensemble.global_comm)
-        self.opts = OptionsManager(flat_solver_parameters, '')
+        self.opts = OptionsManager(self.flat_solver_parameters, '')
         self.snes.setOptionsPrefix('')
         self.snes.setFunction(self.aaos._assemble_function, self.F)
 
@@ -203,8 +203,12 @@ class paradiag(object):
 
             postproc(self, wndw)
 
-            if not (1 < self.snes.getConvergedReason() < 5):
-                PETSc.Sys.Print(f'SNES diverged with error code {self.snes.getConvergedReason()}. Cancelling paradiag time integration.')
+            converged_reason = self.snes.getConvergedReason()
+            is_linear = self.flat_solver_parameters['snes_type'] == 'ksponly'
+            if is_linear and (converged_reason == 5):
+                pass
+            elif not (1 < converged_reason < 5):
+                PETSc.Sys.Print(f'SNES diverged with error code {converged_reason}. Cancelling paradiag time integration.')
                 return
 
             # don't wipe all-at-once function at last window

--- a/asQ/paradiag.py
+++ b/asQ/paradiag.py
@@ -137,6 +137,7 @@ class paradiag(object):
             # copy the snes state vector into self.X
             X.copy(self.X)
             self.aaos.update(X)
+            self.aaos.jacobian.update()
             J.assemble()
             P.assemble()
 

--- a/asQ/paradiag.py
+++ b/asQ/paradiag.py
@@ -204,7 +204,10 @@ class paradiag(object):
             postproc(self, wndw)
 
             converged_reason = self.snes.getConvergedReason()
-            is_linear = self.flat_solver_parameters['snes_type'] == 'ksponly'
+            is_linear = (
+                'snes_type' in self.flat_solver_parameters
+                and self.flat_solver_parameters['snes_type'] == 'ksponly'
+            )
             if is_linear and (converged_reason == 5):
                 pass
             elif not (1 < converged_reason < 5):

--- a/examples/serial/shallow_water/galewsky_comparison.py
+++ b/examples/serial/shallow_water/galewsky_comparison.py
@@ -203,7 +203,7 @@ transfer_managers = []
 for _ in range(time_partition[ensemble.ensemble_comm.rank]):
     tm = mg.manifold_transfer_manager(W)
     transfer_managers.append(tm)
-block_ctx['diag_transfer_managers'] = transfer_managers
+block_ctx['diagfft_transfer_managers'] = transfer_managers
 
 miniapp = ComparisonMiniapp(ensemble, time_partition,
                             form_mass,

--- a/examples/shallow_water/galewsky.py
+++ b/examples/shallow_water/galewsky.py
@@ -94,8 +94,7 @@ sparameters_diag = {
         'atol': 1e-0,
         'rtol': 1e-10,
         'stol': 1e-12,
-        #'ksp_ew': None,
-        #'ksp_ew_threshold': 1e-5
+        'ksp_ew': None,
     },
     'mat_type': 'matfree',
     'ksp_type': 'fgmres',
@@ -106,7 +105,7 @@ sparameters_diag = {
     },
     'pc_type': 'python',
     'pc_python_type': 'asQ.DiagFFTPC',
-    'diagfftpc_jac_average': 'initial'
+    'diagfft_jac_average': 'initial'
 }
 
 sparameters_diag['diagfft_block_'] = sparameters
@@ -123,11 +122,14 @@ miniapp = swe.ShallowWaterMiniApp(gravity=earth.Gravity,
                                   velocity_expression=galewsky.velocity_expression,
                                   depth_expression=galewsky.depth_expression,
                                   reference_depth=galewsky.H0,
+                                  reference_state=True,
                                   create_mesh=create_mesh,
                                   dt=dt, theta=0.5,
                                   alpha=args.alpha, time_partition=time_partition,
                                   paradiag_sparameters=sparameters_diag,
                                   file_name='output/'+args.filename)
+
+miniapp.reference_state.assign(miniapp.aaos.initial_condition)
 
 
 def window_preproc(swe_app, pdg, wndw):

--- a/examples/shallow_water/galewsky.py
+++ b/examples/shallow_water/galewsky.py
@@ -24,6 +24,7 @@ parser.add_argument('--slice_length', type=int, default=2, help='Number of times
 parser.add_argument('--alpha', type=float, default=0.0001, help='Circulant coefficient.')
 parser.add_argument('--dt', type=float, default=0.5, help='Timestep in hours.')
 parser.add_argument('--filename', type=str, default='galewsky', help='Name of output vtk files')
+parser.add_argument('--metrics_dir', type=str, default='metrics', help='Directory to save paradiag metrics to.')
 parser.add_argument('--show_args', action='store_true', help='Output all the arguments.')
 
 args = parser.parse_known_args()
@@ -91,18 +92,21 @@ sparameters_diag = {
         'monitor': None,
         'converged_reason': None,
         'atol': 1e-0,
-        'rtol': 1e-8,
+        'rtol': 1e-10,
         'stol': 1e-12,
-        'max_its': 1
+        #'ksp_ew': None,
+        #'ksp_ew_threshold': 1e-5
     },
     'mat_type': 'matfree',
     'ksp_type': 'fgmres',
     'ksp': {
         'monitor': None,
         'converged_reason': None,
+        'rtol': 1e-5,
     },
     'pc_type': 'python',
-    'pc_python_type': 'asQ.DiagFFTPC'
+    'pc_python_type': 'asQ.DiagFFTPC',
+    'diagfftpc_jac_average': 'initial'
 }
 
 sparameters_diag['diagfft_block_'] = sparameters
@@ -151,7 +155,7 @@ miniapp.solve(nwindows=args.nwindows,
 PETSc.Sys.Print('### === --- Iteration counts --- === ###')
 
 from asQ import write_paradiag_metrics
-write_paradiag_metrics(miniapp.paradiag)
+write_paradiag_metrics(miniapp.paradiag, directory=args.metrics_dir)
 
 PETSc.Sys.Print('')
 

--- a/examples/shallow_water/linear_gravity_bumps.py
+++ b/examples/shallow_water/linear_gravity_bumps.py
@@ -22,7 +22,8 @@ parser.add_argument('--nslices', type=int, default=2, help='Number of time-slice
 parser.add_argument('--slice_length', type=int, default=2, help='Number of timesteps per time-slice.')
 parser.add_argument('--alpha', type=float, default=0.0001, help='Circulant coefficient.')
 parser.add_argument('--dt', type=float, default=0.05, help='Timestep in hours.')
-parser.add_argument('--filename', type=str, default='gravity_waves', help='Name of output vtk files')
+parser.add_argument('--filename', type=str, default='gravity_waves', help='Name of output vtk files.')
+parser.add_argument('--metrics_dir', type=str, default='metrics', help='Directory to save paradiag metrics to.')
 parser.add_argument('--show_args', action='store_true', help='Output all the arguments.')
 
 args = parser.parse_known_args()
@@ -163,7 +164,7 @@ miniapp.solve(nwindows=args.nwindows,
 PETSc.Sys.Print('### === --- Iteration counts --- === ###')
 
 from asQ import write_paradiag_metrics
-write_paradiag_metrics(miniapp.paradiag)
+write_paradiag_metrics(miniapp.paradiag, directory=args.metrics_dir)
 
 PETSc.Sys.Print('')
 

--- a/examples/shallow_water/linear_gravity_bumps.py
+++ b/examples/shallow_water/linear_gravity_bumps.py
@@ -117,8 +117,8 @@ sparameters_diag = {
 }
 
 sparameters_diag['diagfft_block'] = sparameters
-#for i in range(window_length):
-#    sparameters_diag['diagfft_block_'+str(i)+'_'] = sparameters
+# for i in range(window_length):
+#     sparameters_diag['diagfft_block_'+str(i)+'_'] = sparameters
 
 create_mesh = partial(
     swe.create_mg_globe_mesh,

--- a/examples/shallow_water/linear_gravity_bumps.py
+++ b/examples/shallow_water/linear_gravity_bumps.py
@@ -94,6 +94,7 @@ sparameters = {
 }
 
 sparameters_diag = {
+    'snes_type': 'ksponly',
     'snes': {
         'linesearch_type': 'basic',
         'monitor': None,
@@ -113,8 +114,9 @@ sparameters_diag = {
     'pc_python_type': 'asQ.DiagFFTPC'
 }
 
-for i in range(window_length):
-    sparameters_diag['diagfft_block_'+str(i)+'_'] = sparameters
+sparameters_diag['diagfft_block'] = sparameters
+#for i in range(window_length):
+#    sparameters_diag['diagfft_block_'+str(i)+'_'] = sparameters
 
 create_mesh = partial(
     swe.create_mg_globe_mesh,

--- a/examples/shallow_water/linear_gravity_bumps.py
+++ b/examples/shallow_water/linear_gravity_bumps.py
@@ -111,7 +111,8 @@ sparameters_diag = {
         'converged_reason': None,
     },
     'pc_type': 'python',
-    'pc_python_type': 'asQ.DiagFFTPC'
+    'pc_python_type': 'asQ.DiagFFTPC',
+    'diagfft_jac_average': 'linear'
 }
 
 sparameters_diag['diagfft_block'] = sparameters

--- a/examples/shallow_water/williamson2.py
+++ b/examples/shallow_water/williamson2.py
@@ -154,7 +154,7 @@ for _ in range(nlocal_timesteps):
     tm = mg.manifold_transfer_manager(W)
     transfer_managers.append(tm)
 
-block_ctx['diag_transfer_managers'] = transfer_managers
+block_ctx['diagfft_transfer_managers'] = transfer_managers
 
 PD = asQ.paradiag(ensemble=ensemble,
                   form_function=form_function,

--- a/tests/test_paradiag.py
+++ b/tests/test_paradiag.py
@@ -631,6 +631,7 @@ def test_jacobian_mixed_parallel():
 
     # use PD to calculate the Jacobian
     Jac1 = PD.aaos.jacobian
+    Jac1.update()  # updates Jacobian state from aaos
 
     # construct Petsc vector X1, Y1:
     nlocal = M[rT]*W.node_set.size  # local times x local space

--- a/utils/shallow_water/williamson1992/case5.py
+++ b/utils/shallow_water/williamson1992/case5.py
@@ -76,7 +76,7 @@ def topography_expression(x, y, z,
     lambda2 = pow(lambda_x - lambda_c, 2)
     theta2 = pow(theta_x - theta_c, 2)
 
-    min_arg = fd.Min(radius2, theta2 + lambda2)
+    min_arg = fd.min_value(radius2, theta2 + lambda2)
 
     return height*(1 - fd.sqrt(min_arg)/radius)
 


### PR DESCRIPTION
This PR adds different ways of setting the linearisations in the Jacobian and the preconditioner.

Specifying the state to linearise around for the preconditioner:
- [x] Time average over window. 
- [x] Average over time slice.
- [x] Don't bother doing any averaging for linear equations.
- [x] The window initial condition.
- [x] A provided reference state.

Specifying the state to use for the all-at-once Jacobian:
- [ ] The current state of the AllAtOnceSystem.
- [ ] The window initial condition.
- [ ] A provided reference state.

Specifying the form to linearise to use for the preconditioner:
- [ ] The form of the original equation.
- [ ] A different provided form.

Specifying the form to linearise to use for the all-at-once Jacobian:
- [ ] The form of the original equation.
- [ ] A different provided form.