### PR TITLE
Use AllAtOnceSystem state as initial guess for PETSc solve at each window

### DIFF
--- a/asQ/allatoncesystem.py
+++ b/asQ/allatoncesystem.py
@@ -95,8 +95,8 @@ class AllAtOnceSystem(object):
         self.nlocal_timesteps = self.layout.local_size
         self.ntimesteps = self.layout.global_size
 
-        self.initial_condition = w0
         self.function_space = w0.function_space()
+        self.initial_condition = fd.Function(self.function_space).assign(w0)
         self.boundary_conditions = bcs
         self.ncomponents = len(self.function_space.subfunctions)
 

--- a/asQ/paradiag.py
+++ b/asQ/paradiag.py
@@ -195,8 +195,12 @@ class paradiag(object):
 
             preproc(self, wndw)
 
+            with self.aaos.w_all.dat.vec_ro as v:
+                v.copy(self.X)
+
             with self.opts.inserted_options():
                 self.snes.solve(None, self.X)
+
             self.aaos.update(self.X)
 
             self._record_diagnostics()


### PR DESCRIPTION
This PR fixes a bug for moving from one window to the next.

After each window solve, we copy the solution into the all-at-once function of the AllAtOnceSystem, which is correct. However, before each window  solve, we don't copy the all-at-once-function into the PETSc Vec used for the solve.

This is incorrect because the value of this Vec at the beginning of the solve is used as the initial guess. This means that so far we have actually been using the solution of the previous window as the initial guess to the next window, instead of using window initial condition.


There are also two other small changes:
1. AllAtOnceSystem now makes a copy of the initial conditions, rather than just keeping a handle to the function that the user provides.
2. Slight change in how we check the ConvergedReason of the all-at-once solve so that we can use 'snes_type': 'ksponly' for linear systems.