### PR TITLE
Remove mpi4py-fftw from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,8 +47,6 @@ jobs:
         run: |
           . /home/firedrake/firedrake/bin/activate
           firedrake-status
-          FFTW_INCLUDE_DIR=/home/firedrake/firedrake/src/petsc/default/include FFTW_LIBRARY_DIR=/home/firedrake/firedrake/src/petsc/default/lib python -m pip install mpi4py-fft 
-          python -m pip install --upgrade scipy
           python -m pip install -e .
       - name: Lint
         run: |
@@ -57,4 +55,4 @@ jobs:
       - name: Test
         run: |
           . /home/firedrake/firedrake/bin/activate
-          python -m pytest -vvv -s -n 4 --durations=0 --timeout=600 --cov=asQ tests/
+          python -m pytest -vvv -s -n 6 --durations=0 --timeout=600 --cov=asQ tests/


### PR DESCRIPTION
Firedrake have stopped installing FFTW with PETSc in the docker image [here](https://github.com/firedrakeproject/firedrake/commit/b612fdf04a5155f0d5c3c3c703cac9fe2d5ddd82#diff-48962ef94944cbfed38c0c668970c73c105accafcdf2411b684153ade7db560a). This has made our CI break when it tries to install `mpi4py-fftw` because it can't find the FFTW library to link against.

We don't actually use `mpi4py-fftw` any more since we moved a copy of `pencil.py` into asQ, so we don't need to install it in the CI. Until we get around to using FFTW instead of `scipy.fft`, I think we can remove these lines from the CI.