### PR TITLE
Precompute symbolic Jacobian action

### DIFF
--- a/asQ/allatoncesystem.py
+++ b/asQ/allatoncesystem.py
@@ -35,6 +35,9 @@ class JacobianMatrix(object):
         self.Jform_prev = fd.derivative(self.aaos.aao_form,
                                         self.aaos.w_recv)
 
+        self.Jaction = fd.action(self.Jform, self.u)
+        self.Jaction_prev = fd.action(self.Jform_prev, self.urecv)
+
     @PETSc.Log.EventDecorator()
     @memprofile
     def mult(self, mat, X, Y):
@@ -48,9 +51,8 @@ class JacobianMatrix(object):
             self.aaos.Circ.assign(0.0)
 
         # assembly stage
-        fd.assemble(fd.action(self.Jform, self.u), tensor=self.F)
-        fd.assemble(fd.action(self.Jform_prev, self.urecv),
-                    tensor=self.F_prev)
+        fd.assemble(self.Jaction, tensor=self.F)
+        fd.assemble(self.Jaction_prev, tensor=self.F_prev)
         self.F += self.F_prev
 
         # unset flag if alpha-circulant approximation only in Jacobian


### PR DESCRIPTION
To apply the action of the Jacobian requires two steps:

1. Compute the symbolic `action` of the `derivative` of the all-at-once form.
2. Numerically `assemble` the action on a specific vector.

Currently we do both of these in `JacobianMatrix.mult`:
```
fd.assemble(fd.action(self.Jform, self.u), tensor=self.F)                                                                                                                                              
fd.assemble(fd.action(self.Jform_prev, self.urecv), tensor=self.F_prev)
```

However, because the `action` is symbolic we can precompute this in `JacobianMatrix.__init__` and reuse each time. This drastically reduces the time spent in `JacobianMatrix.mult`.

Demonstration for Galewsky with the following setup (exact numbers will vary in different cases):
```
mpiexec -np 8 python galewsky.py --show_args --ref_level 3 --nslices 4 --slice_length 1 --nwindows 8 --dt 1 -log_view :log.txt:ascii_flamegraph
```

When calculating the `action` at every Jacobian application the MatMult on the outer KSPSolve takes 13-15% of the total time, with the call to `action` taking just over a third of the time :
![log_old](https://github.com/firedrakeproject/asQ/assets/26110499/052a2d86-7ee6-42f8-b773-4095d0c66be1)

Zoom of MatMult:
![log_old_zoom](https://github.com/firedrakeproject/asQ/assets/26110499/2f8d8b4d-b369-4a74-b37f-6995be87bdef)


When precalculating the `action` the MatMult takes ~1% of the total time:
![log_new](https://github.com/firedrakeproject/asQ/assets/26110499/6a6d1338-af1b-4914-bfad-341694c7fb3c)

Zoom of MatMult:
![log_new_zoom](https://github.com/firedrakeproject/asQ/assets/26110499/5ed8b0cd-e168-4784-99d8-8fcefa8febef)

As well as removing the call to `action`, the time spent in `assemble` reduces too, mostly because of less time spent in `firedrake.tsfc_interface.compile_form`. I think when the `action` gets recalculated every time tsfc also recompiles the assemble kernel. When the `action` is precomputed, the majority (~60%) of the time spent in `MatMult` is spent in `ParLoopExecute`, as should be expected.