### PR TITLE
Only transpose real-valued data where possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 *.out
 .coverage*
 **/metrics/*
+*.svg

--- a/asQ/allatoncesystem.py
+++ b/asQ/allatoncesystem.py
@@ -1,8 +1,7 @@
 import firedrake as fd
-from firedrake.petsc import PETSc
 from functools import reduce
 from operator import mul
-from asQ.profiling import memprofile
+from asQ.profiling import profiler
 from asQ.common import get_option_from_list
 from functools import partial
 
@@ -71,7 +70,7 @@ class JacobianMatrix(object):
     """
     prefix = "aaos_jacobian_"
 
-    @memprofile
+    @profiler()
     def __init__(self, aaos, snes=None):
         r"""
         Python matrix for the Jacobian of the all at once system
@@ -188,8 +187,7 @@ class JacobianMatrix(object):
         self.Jaction = fd.action(self.Jform, self.u)
         self.Jaction_prev = fd.action(self.Jform_prev, self.urecv)
 
-    @PETSc.Log.EventDecorator()
-    @memprofile
+    @profiler()
     def mult(self, mat, X, Y):
 
         self.aaos.update(X, wall=self.x, wrecv=self.xrecv, blocking=True)
@@ -224,7 +222,7 @@ class JacobianMatrix(object):
 
 
 class AllAtOnceSystem(object):
-    @memprofile
+    @profiler()
     def __init__(self,
                  ensemble, time_partition,
                  dt, theta,
@@ -382,7 +380,7 @@ class AllAtOnceSystem(object):
             cpt = cpt % self.max_indices['component']
             return i*self.ncomponents + cpt
 
-    @PETSc.Log.EventDecorator()
+    @profiler()
     def set_component(self, step, cpt, wnew, index_range='slice', f_alls=None):
         '''
         Set component of solution at a timestep to new value
@@ -401,7 +399,7 @@ class AllAtOnceSystem(object):
 
         f_alls[aao_index].assign(wnew)
 
-    @PETSc.Log.EventDecorator()
+    @profiler()
     def get_component(self, step, cpt, index_range='slice', wout=None, name=None, f_alls=None, deepcopy=False):
         '''
         Get component of solution at a timestep
@@ -448,7 +446,7 @@ class AllAtOnceSystem(object):
         return tuple(self.get_component(step, cpt, f_alls=f_alls)
                      for cpt in range(self.ncomponents))
 
-    @PETSc.Log.EventDecorator()
+    @profiler()
     def set_field(self, step, wnew, index_range='slice', f_alls=None):
         '''
         Set solution at a timestep to new value
@@ -462,7 +460,7 @@ class AllAtOnceSystem(object):
             self.set_component(step, cpt, wnew.sub(cpt),
                                index_range=index_range, f_alls=f_alls)
 
-    @PETSc.Log.EventDecorator()
+    @profiler()
     def get_field(self, step, index_range='slice', wout=None, name=None, f_alls=None):
         '''
         Get solution at a timestep
@@ -484,7 +482,7 @@ class AllAtOnceSystem(object):
 
         return wget
 
-    @PETSc.Log.EventDecorator()
+    @profiler()
     def for_each_timestep(self, callback):
         '''
         call callback for each timestep in each slice in the current window
@@ -501,7 +499,7 @@ class AllAtOnceSystem(object):
             self.get_field(slice_index, wout=w, index_range='slice')
             callback(window_index, slice_index, w)
 
-    @PETSc.Log.EventDecorator()
+    @profiler()
     def next_window(self, w1=None):
         """
         Reset all-at-once-system ready for next time-window
@@ -528,7 +526,7 @@ class AllAtOnceSystem(object):
         self.t0.assign(self.t0 + self.dt*self.ntimesteps)
         return
 
-    @PETSc.Log.EventDecorator()
+    @profiler()
     def update_time_halos(self, wsend=None, wrecv=None, walls=None, blocking=True):
         '''
         Update wrecv with the last step from the previous slice (periodic) of walls
@@ -564,7 +562,7 @@ class AllAtOnceSystem(object):
         return sendrecv(fsend=wsend, dest=dst, sendtag=rank,
                         frecv=wrecv, source=src, recvtag=src)
 
-    @PETSc.Log.EventDecorator()
+    @profiler()
     def update(self, X, wall=None, wsend=None, wrecv=None, blocking=True):
         '''
         Update self.w_alls and self.w_recv from PETSc Vec X.
@@ -587,8 +585,7 @@ class AllAtOnceSystem(object):
                                       walls=wall.subfunctions,
                                       blocking=blocking)
 
-    @PETSc.Log.EventDecorator()
-    @memprofile
+    @profiler()
     def _assemble_function(self, snes, X, Fvec):
         r"""
         This is the function we pass to the snes to assemble

--- a/asQ/complex_proxy/mixed_impl.py
+++ b/asQ/complex_proxy/mixed_impl.py
@@ -5,6 +5,8 @@ from asQ.complex_proxy.common import (Part, re, im, api_names,  # noqa:F401
                                       _flatten_tree,
                                       _build_oneform, _build_twoform)  # noqa: F401
 
+from asQ.profiling import profiler
+
 __all__ = api_names
 
 
@@ -141,6 +143,7 @@ def _set_part(u, vnew, i):
         csub.assign(rsub)
 
 
+@profiler()
 def get_real(u, vout):
     """
     Copy the real component of the complex Function u into the real-valued Function vout
@@ -151,6 +154,7 @@ def get_real(u, vout):
     return _get_part(u, vout, Part.Real)
 
 
+@profiler()
 def get_imag(u, vout, name=None):
     """
     Copy the imaginary component of the complex Function u into the real-valued Function vout
@@ -161,6 +165,7 @@ def get_imag(u, vout, name=None):
     return _get_part(u, vout, Part.Imag)
 
 
+@profiler()
 def set_real(u, vnew):
     """
     Copy the real-valued Function vnew into the real part of the complex Function u.
@@ -171,6 +176,7 @@ def set_real(u, vnew):
     _set_part(u, vnew, Part.Real)
 
 
+@profiler()
 def set_imag(u, vnew):
     """
     Copy the real-valued Function vnew into the imaginary part of the complex Function u.
@@ -181,6 +187,7 @@ def set_imag(u, vnew):
     _set_part(u, vnew, Part.Imag)
 
 
+@profiler()
 def LinearForm(W, z, f, return_z=False):
     """
     Return a Linear Form on the complex FunctionSpace W equal to a complex multiple of a linear Form on the real FunctionSpace.
@@ -195,6 +202,7 @@ def LinearForm(W, z, f, return_z=False):
     return _build_oneform(W, z, f, split, return_z)
 
 
+@profiler()
 def BilinearForm(W, z, A, return_z=False):
     """
     Return a bilinear Form on the complex FunctionSpace W equal to a complex multiple of a bilinear Form on the real FunctionSpace.
@@ -215,6 +223,7 @@ def BilinearForm(W, z, A, return_z=False):
     return _build_twoform(W, z, A, fd.TrialFunction(W), split, return_z)
 
 
+@profiler()
 def derivative(z, F, u, return_z=False):
     """
     Return a bilinear Form equivalent to z*J where z is a complex number, J = dF/dw, F is a nonlinear Form on the real-valued space, and w is a Function in the real-valued space. The real and imaginary components of the complex Function u most both be equal to w for this operation to be valid.

--- a/asQ/complex_proxy/vector_impl.py
+++ b/asQ/complex_proxy/vector_impl.py
@@ -6,6 +6,8 @@ from ufl.classes import MultiIndex, FixedIndex, Indexed
 from asQ.complex_proxy.common import (Part, re, im, api_names,  # noqa:F401
                                       _build_oneform, _build_twoform)  # noqa: F401
 
+from asQ.profiling import profiler
+
 __all__ = api_names
 
 
@@ -167,6 +169,7 @@ def _set_part(u, vnew, i):
         csub.assign(rsub)
 
 
+@profiler()
 def get_real(u, vout, name=None):
     """
     Return a real Function equal to the real component of the complex Function u.
@@ -180,6 +183,7 @@ def get_real(u, vout, name=None):
     return _get_part(u, vout, Part.Real)
 
 
+@profiler()
 def get_imag(u, vout, name=None):
     """
     Return a real Function equal to the imaginary component of the complex Function u.
@@ -193,6 +197,7 @@ def get_imag(u, vout, name=None):
     return _get_part(u, vout, Part.Imag)
 
 
+@profiler()
 def set_real(u, vnew):
     """
     Set the real component of the complex Function u to the value of the real Function vnew.
@@ -203,6 +208,7 @@ def set_real(u, vnew):
     _set_part(u, vnew, Part.Real)
 
 
+@profiler()
 def set_imag(u, vnew):
     """
     Set the imaginary component of the complex Function u to the value of the real Function vnew.
@@ -213,6 +219,7 @@ def set_imag(u, vnew):
     _set_part(u, vnew, Part.Imag)
 
 
+@profiler()
 def LinearForm(W, z, f, return_z=False):
     """
     Return a Linear Form on the complex FunctionSpace W equal to a complex multiple of a linear Form on the real FunctionSpace.
@@ -227,6 +234,7 @@ def LinearForm(W, z, f, return_z=False):
     return _build_oneform(W, z, f, split, return_z)
 
 
+@profiler()
 def BilinearForm(W, z, A, return_z=False):
     """
     Return a bilinear Form on the complex FunctionSpace W equal to a complex multiple of a bilinear Form on the real FunctionSpace.
@@ -247,6 +255,7 @@ def BilinearForm(W, z, A, return_z=False):
     return _build_twoform(W, z, A, fd.TrialFunction(W), split, return_z)
 
 
+@profiler()
 def derivative(z, F, u, return_z=False):
     """
     Return a bilinear Form equivalent to z*J where z is a complex number, J = dF/dw, F is a nonlinear Form on the real-valued space, and w is a Function in the real-valued space. The real and imaginary components of the complex Function u most both be equal to w for this operation to be valid.

--- a/asQ/diag_preconditioner.py
+++ b/asQ/diag_preconditioner.py
@@ -163,7 +163,7 @@ class DiagFFTPC(object):
         self.xfr = fd.Function(W_all)
 
         # setting up the FFT stuff
-        self.smaller_transpose = False
+        self.smaller_transpose = True
         # construct simply dist array and 1d fftn:
         subcomm = Subcomm(self.ensemble.ensemble_comm, [0, 1])
 

--- a/asQ/diag_preconditioner.py
+++ b/asQ/diag_preconditioner.py
@@ -117,7 +117,6 @@ class DiagFFTPC(object):
 
         # Input/Output wrapper Functions for all-at-once residual being acted on
         self.xf = fd.Function(W_all)  # input
-        self.yf = fd.Function(W_all)  # output
 
         # Gamma coefficients
         exponents = np.arange(self.ntimesteps)/self.ntimesteps
@@ -164,20 +163,44 @@ class DiagFFTPC(object):
         self.xfr = fd.Function(W_all)
 
         # setting up the FFT stuff
+        self.smaller_transpose = False
         # construct simply dist array and 1d fftn:
         subcomm = Subcomm(self.ensemble.ensemble_comm, [0, 1])
+
         # dimensions of space-time data in this ensemble_comm
         nlocal = self.blockV.node_set.size
         NN = np.array([self.ntimesteps, nlocal], dtype=int)
+
         # transfer pencil is aligned along axis 1
         self.p0 = Pencil(subcomm, NN, axis=1)
-        # a0 is the local part of our fft working array
-        # has shape of (partition/P, nlocal)
-        self.a0 = np.zeros(self.p0.subshape, complex)
         self.p1 = self.p0.pencil(0)
-        # a0 is the local part of our other fft working array
-        self.a1 = np.zeros(self.p1.subshape, complex)
-        self.transfer = self.p0.transfer(self.p1, complex)
+
+        # data types
+        rtype = self.xf.dat[0].data.dtype
+        ctype = complex
+
+        # set up real valued transfer
+        self.rtransfer = self.p0.transfer(self.p1, rtype)
+
+        # a0 is the local part of the original data (i.e. distributed in time)
+        # has shape of (nlocal_timesteps, nlocal)
+        self.ra0 = np.zeros(self.p0.subshape, rtype)
+
+        # a1 is the local part of the transposed data (i.e. distributed in space)
+        # has shape of (ntimesteps, ...)
+        self.ra1 = np.zeros(self.p1.subshape, rtype)
+
+        # set up complex valued transfer
+
+        # a0 is the local part of the original data (i.e. distributed in time)
+        # has shape of (nlocal_timesteps, nlocal)
+        self.ca0 = np.zeros(self.p0.subshape, ctype)
+
+        # a1 is the local part of the transposed data (i.e. distributed in space)
+        # has shape of (ntimesteps, ...)
+        self.ca1 = np.zeros(self.p1.subshape, ctype)
+
+        self.ctransfer = self.p0.transfer(self.p1, ctype)
 
         # setting up the Riesz map
         default_riesz_method = {
@@ -360,30 +383,39 @@ class DiagFFTPC(object):
 
         # get array of basis coefficients
         with self.xf.dat.vec_ro as v:
-            parray = v.array_r.reshape((self.aaos.nlocal_timesteps,
-                                        self.blockV.node_set.size))
+            self.ra0[:] = v.array_r.reshape((self.aaos.nlocal_timesteps,
+                                             self.blockV.node_set.size))
         # This produces an array whose rows are time slices
         # and columns are finite element basis coefficients
 
         ######################
         # Diagonalise - scale, transfer, FFT, transfer, Copy
         # Scale
-        # is there a better way to do this with broadcasting?
-        parray = (1.0+0.j)*(self.Gam_slice*parray.T).T*np.sqrt(self.ntimesteps)
+
         # transfer forward
-        self.a0[:] = parray[:]
-        self.transfer.forward(self.a0, self.a1)
+        if self.smaller_transpose:
+            # is there a better way to do this with broadcasting?
+            self.ra0[:] = (self.Gam_slice*self.ra0.T).T*np.sqrt(self.ntimesteps)
+
+            self.rtransfer.forward(self.ra0, self.ra1)
+
+            self.ca1[:] = self.ra1[:]
+        else:
+            # is there a better way to do this with broadcasting?
+            self.ca0[:] = (self.Gam_slice*self.ra0.T).T*np.sqrt(self.ntimesteps)
+
+            self.ctransfer.forward(self.ca0, self.ca1)
+
         # FFT
-        self.a1[:] = fft(self.a1, axis=0)
+        self.ca1[:] = fft(self.ca1, axis=0)
 
         # transfer backward
-        self.transfer.backward(self.a1, self.a0)
+        self.ctransfer.backward(self.ca1, self.ca0)
         # Copy into xfi, xfr
-        parray[:] = self.a0[:]
         with self.xfr.dat.vec_wo as v:
-            v.array[:] = parray.real.reshape(-1)
+            v.array[:] = self.ca0.real.reshape(-1)
         with self.xfi.dat.vec_wo as v:
-            v.array[:] = parray.imag.reshape(-1)
+            v.array[:] = self.ca0.imag.reshape(-1)
         #####################
 
         # Do the block solves
@@ -410,27 +442,38 @@ class DiagFFTPC(object):
         ######################
         # Undiagonalise - Copy, transfer, IFFT, transfer, scale, copy
         # get array of basis coefficients
-        with self.xfi.dat.vec_ro as v:
-            parray = 1j*v.array_r.reshape((self.aaos.nlocal_timesteps,
-                                           self.blockV.node_set.size))
         with self.xfr.dat.vec_ro as v:
-            parray += v.array_r.reshape((self.aaos.nlocal_timesteps,
-                                         self.blockV.node_set.size))
+            self.ca0.real[:] = v.array_r.reshape((self.aaos.nlocal_timesteps,
+                                                  self.blockV.node_set.size))
+        with self.xfi.dat.vec_ro as v:
+            self.ca0.imag[:] = v.array_r.reshape((self.aaos.nlocal_timesteps,
+                                                  self.blockV.node_set.size))
         # transfer forward
-        self.a0[:] = parray[:]
-        self.transfer.forward(self.a0, self.a1)
+        self.ctransfer.forward(self.ca0, self.ca1)
         # IFFT
-        self.a1[:] = ifft(self.a1, axis=0)
-        # transfer backward
-        self.transfer.backward(self.a1, self.a0)
-        parray[:] = self.a0[:]
-        # scale
-        parray = ((1.0/self.Gam_slice)*parray.T).T
-        # Copy into xfi, xfr
-        with self.yf.dat.vec_wo as v:
-            v.array[:] = parray.reshape(-1).real
-        with self.yf.dat.vec_ro as v:
-            v.copy(y)
+        self.ca1[:] = ifft(self.ca1, axis=0)
+
+        if self.smaller_transpose:
+            # transfer backward
+            self.ra1[:] = self.ca1.real[:]
+            self.rtransfer.backward(self.ra1, self.ra0)
+
+            # scale
+            self.ra0[:] = ((1.0/self.Gam_slice)*self.ra0[:].T).T
+
+            # Copy into output
+            y.array[:] = self.ra0.reshape(-1)
+
+        else:
+            # transfer backward
+            self.ctransfer.backward(self.ca1, self.ca0)
+
+            # scale
+            self.ca0[:] = ((1.0/self.Gam_slice)*self.ca0[:].T).T
+
+            # Copy into output
+            y.array[:] = self.ca0.reshape(-1).real
+
         ################
 
         self._record_diagnostics()

--- a/asQ/profiling.py
+++ b/asQ/profiling.py
@@ -1,22 +1,56 @@
 import os
 
-# profile memory use
-if os.getenv("ASQ_PROFILE_MEM") is not None:
-    from memory_profiler import profile
-    if os.getenv("ASQ_PROFILE_MEM") == "file":
-        # log memory profile to file (one per MPI rank)
-        from mpi4py import MPI
-        from functools import partial
-        rank = MPI.COMM_WORLD.rank
-        mprof_file = open(f"asq_memprof_log{rank}.dat", "w")
-        memprofile = partial(profile, stream=mprof_file)
-    else:
-        # log memory profile to stdout
-        memprofile = profile
+profile_type = os.getenv("ASQ_PROFILE")
 
-# no memory profile
-else:
-    def memprofile(func):
+# default is to profile timing
+if profile_type is None:
+    profile_type = "PETSC_LOG"
+
+# profile timing
+if profile_type == "PETSC_LOG":
+    from firedrake.petsc import PETSc
+
+    def profiler():
+        return PETSc.Log.EventDecorator()
+
+# profile memory use
+elif profile_type == "MEMORY":
+    from memory_profiler import profile
+
+    def profiler():
+        return profile
+
+# profile memory use and output results to one file per rank
+elif profile_type == "MEMORY_FILE":
+    from memory_profiler import profile
+    from mpi4py import MPI
+    from functools import partial
+    rank = MPI.COMM_WORLD.rank
+    mprof_file = open(f"asq_memprof_log{rank}.dat", "w")
+    prof = partial(profile, stream=mprof_file)
+
+    def profiler():
+        return prof
+
+# do not profile
+elif profile_type == "NONE":
+    def prof(func):
         def pass_through(*args, **kwargs):
             return func(*args, **kwargs)
         return pass_through
+
+    def profiler():
+        return prof
+
+# unknown profile type
+else:
+    import warnings
+    warnings.warn(f"Unknown profile type ASQ_PROFILE={profile_type}. Defaulting to no profiling.")
+
+    def prof(func):
+        def pass_through(*args, **kwargs):
+            return func(*args, **kwargs)
+        return pass_through
+
+    def profiler():
+        return prof

--- a/examples/advection/periodic_dg_advection.py
+++ b/examples/advection/periodic_dg_advection.py
@@ -23,7 +23,9 @@ parser.add_argument('--nslices', type=int, default=2, help='Number of time-slice
 parser.add_argument('--slice_length', type=int, default=2, help='Number of timesteps per time-slice.')
 parser.add_argument('--alpha', type=float, default=0.0001, help='Circulant coefficient.')
 parser.add_argument('--nsample', type=int, default=32, help='Number of sample points for plotting.')
-parser.add_argument('--show_args', action='store_true', help='Output all the arguments.')
+parser.add_argument('--mpeg', action='store_true', help='Output an mpeg of the timeseries.')
+parser.add_argument('--write_metrics', action='store_true', help='Write various solver metrics to file.')
+parser.add_argument('--show_args', action='store_true', default=True, help='Output all the arguments.')
 
 args = parser.parse_known_args()
 args = args[0]
@@ -111,8 +113,9 @@ def form_function(q, phi, t):
 # The PETSc solver parameters used to solve the
 # blocks in step (b) of inverting the ParaDiag matrix.
 block_parameters = {
-    'ksp_type': 'gmres',
-    'pc_type': 'bjacobi',
+    'ksp_type': 'preonly',
+    'pc_type': 'lu',
+    'pc_factor_mat_solver_type': 'mumps'
 }
 
 # The PETSc solver parameters for solving the all-at-once system.
@@ -129,22 +132,24 @@ block_parameters = {
 #    The solver options for this are:
 #    'ksp_type': 'preonly'
 
+atol = 1e-10
+rtol = 1e-8
 paradiag_parameters = {
+    'snes_type': 'ksponly',
     'snes': {
-        'linesearch_type': 'basic',
         'monitor': None,
         'converged_reason': None,
-        'rtol': 1e-10,
-        'atol': 1e-12,
+        'rtol': rtol,
+        'atol': atol,
         'stol': 1e-12,
     },
     'mat_type': 'matfree',
-    'ksp_type': 'preonly',
+    'ksp_type': 'gmres',
     'ksp': {
         'monitor': None,
         'converged_reason': None,
-        'rtol': 1e-10,
-        'atol': 1e-12,
+        'rtol': rtol,
+        'atol': atol,
         'stol': 1e-12,
     },
     'pc_type': 'python',
@@ -228,10 +233,11 @@ PETSc.Sys.Print(f'block linear iterations: {pdg.block_iterations._data}  |  iter
 
 # We can write these diagnostics to file, along with some other useful information.
 # Files written are: aaos_metrics.txt, block_metrics.txt, paradiag_setup.txt, solver_parameters.txt
-asQ.write_paradiag_metrics(pdg)
+if args.write_metrics:
+    asQ.write_paradiag_metrics(pdg)
 
 # Make an animation from the snapshots we collected and save it to periodic.mp4.
-if is_last_slice:
+if is_last_slice and args.mpeg:
 
     fn_plotter = fd.FunctionPlotter(mesh, num_sample_points=args.nsample)
 

--- a/examples/shallow_water/galewsky.py
+++ b/examples/shallow_water/galewsky.py
@@ -1,4 +1,5 @@
 
+import firedrake as fd  # noqa: F401
 from petsc4py import PETSc
 
 from utils import units
@@ -92,10 +93,10 @@ sparameters = {
     'ksp': {
         'atol': 1e-5,
         'rtol': 1e-5,
-        'max_it': 60
+        'max_it': 50,
     },
     'pc_type': 'mg',
-    'pc_mg_cycle_type': 'w',
+    'pc_mg_cycle_type': 'v',
     'pc_mg_type': 'multiplicative',
     'mg': mg_parameters
 }
@@ -110,6 +111,7 @@ sparameters_diag = {
         'stol': 1e-12,
         'ksp_ew': None,
         'ksp_ew_version': 1,
+        'ksp_ew_threshold': 1e-2,
     },
     'mat_type': 'matfree',
     'ksp_type': 'fgmres',
@@ -144,7 +146,7 @@ miniapp = swe.ShallowWaterMiniApp(gravity=earth.Gravity,
                                   dt=dt, theta=0.5,
                                   alpha=args.alpha, time_partition=time_partition,
                                   paradiag_sparameters=sparameters_diag,
-                                  file_name='output/'+args.filename)
+                                  record_diagnostics={'cfl': True, 'file': False})
 
 
 ics = miniapp.aaos.initial_condition

--- a/examples/shallow_water/williamson2.py
+++ b/examples/shallow_water/williamson2.py
@@ -27,7 +27,8 @@ parser.add_argument('--nslices', type=int, default=2, help='Number of time-slice
 parser.add_argument('--slice_length', type=int, default=2, help='Number of timesteps per time-slice.')
 parser.add_argument('--alpha', type=float, default=0.0001, help='Circulant coefficient.')
 parser.add_argument('--dt', type=float, default=0.5, help='Timestep in hours.')
-parser.add_argument('--filename', type=str, default='w5diag', help='Name of output vtk files')
+parser.add_argument('--coords_degree', type=int, default=1, help='Degree of polynomials for sphere mesh approximation.')
+parser.add_argument('--filename', type=str, default='williamson2', help='Name of output vtk files')
 parser.add_argument('--degree', type=int, default=1, help='Degree of finite element space (the DG space).')
 parser.add_argument('--show_args', action='store_true', help='Output all the arguments.')
 
@@ -141,7 +142,7 @@ sparameters = {
     'ksp': {
         'atol': 1e-5,
         'rtol': 1e-5,
-        'max_it': 60
+        'max_it': 50,
     },
     'pc_type': 'mg',
     'pc_mg_cycle_type': 'w',
@@ -160,6 +161,7 @@ sparameters_diag = {
         'stol': 1e-12,
         'ksp_ew': None,
         'ksp_ew_version': 1,
+        'ksp_ew_threshold': 1e-2,
     },
     'mat_type': 'matfree',
     'ksp_type': 'fgmres',

--- a/examples/shallow_water/williamson5.py
+++ b/examples/shallow_water/williamson5.py
@@ -94,7 +94,8 @@ sparameters_diag['diagfft_block_'] = sparameters
 
 create_mesh = partial(
     swe.create_mg_globe_mesh,
-    ref_level=args.ref_level)
+    ref_level=args.ref_level,
+    degree=1)
 
 # initial conditions
 b_exp = case5.topography_expression

--- a/utils/diagnostics.py
+++ b/utils/diagnostics.py
@@ -1,5 +1,6 @@
 
 import firedrake as fd
+from asQ.profiling import profiler
 
 
 def convective_cfl_calculator(mesh,
@@ -32,6 +33,7 @@ def convective_cfl_calculator(mesh,
     def both(u):
         return 2*fd.avg(u)
 
+    @profiler()
     def cfl_calc(u, dt):
         # area weighted convective flux
         n = fd.FacetNormal(u.function_space().mesh())
@@ -49,6 +51,7 @@ def convective_cfl_calculator(mesh,
     return cfl_calc
 
 
+@profiler()
 def convective_cfl(u, dt):
     '''
     Return the convective CFL number for the velocity field u with timestep dt
@@ -98,6 +101,7 @@ def potential_vorticity_calculator(
     pv_solver = fd.LinearVariationalSolver(pv_prob,
                                            solver_parameters=params)
 
+    @profiler()
     def pv_calc(u):
         vel.assign(u)
         pv_solver.solve()


### PR DESCRIPTION
This PR addresses issue #110 "Lower all-to-all communication volume in fft transposes".

The first and last data transposes in the preconditioner need only be on real-valued data: the vector acted on is real, and the return vector is real. This halves the communication volume of 2/4 transpose operations.