### PR TITLE
Remove explicit `PETSc.EventDecorator` calls

### DIFF
--- a/asQ/allatonce/form.py
+++ b/asQ/allatonce/form.py
@@ -109,6 +109,7 @@ class AllAtOnceForm(TimePartitionMixin):
 
         return bcs_all
 
+    @profiler()
     def copy(self, aaofunc=None):
         """
         Return a copy of the AllAtOnceForm.
@@ -124,7 +125,6 @@ class AllAtOnceForm(TimePartitionMixin):
                              self.form_mass, self.form_function,
                              bcs=self.field_bcs, alpha=self.alpha)
 
-    @PETSc.Log.EventDecorator()
     @profiler()
     def assemble(self, func=None, tensor=None):
         """

--- a/asQ/allatonce/function.py
+++ b/asQ/allatonce/function.py
@@ -10,6 +10,7 @@ from asQ.allatonce.mixin import TimePartitionMixin
 __all__ = ['time_average', 'AllAtOnceFunction']
 
 
+@profiler()
 def time_average(aaofunc, uout, uwrk, average='window'):
     """
     Compute the time average of an all-at-once function

--- a/asQ/allatonce/jacobian.py
+++ b/asQ/allatonce/jacobian.py
@@ -1,5 +1,4 @@
 import firedrake as fd
-from firedrake.petsc import PETSc
 from functools import partial
 
 from asQ.profiling import profiler

--- a/asQ/allatonce/jacobian.py
+++ b/asQ/allatonce/jacobian.py
@@ -105,7 +105,7 @@ class AllAtOnceJacobian(TimePartitionMixin):
 
         self.update()
 
-    @PETSc.Log.EventDecorator()
+    @profiler()
     def update(self, X=None):
         """
         Update the state to linearise around according to aaos_jacobian_state.
@@ -141,7 +141,6 @@ class AllAtOnceJacobian(TimePartitionMixin):
 
         return
 
-    @PETSc.Log.EventDecorator()
     @profiler()
     def mult(self, mat, X, Y):
         """

--- a/asQ/allatonce/solver.py
+++ b/asQ/allatonce/solver.py
@@ -113,7 +113,6 @@ class AllAtOnceSolver(TimePartitionMixin):
         self.jacobian_mat = jacobian_mat
 
         def form_jacobian(snes, X, J, P):
-            # copy the snes state vector into self.X
             self.pre_jacobian_callback(self, X, J)
             self.jacobian.update(X)
             self.post_jacobian_callback(self, X, J)

--- a/asQ/allatonce/solver.py
+++ b/asQ/allatonce/solver.py
@@ -125,7 +125,6 @@ class AllAtOnceSolver(TimePartitionMixin):
         # complete the snes setup
         self.options.set_from_options(self.snes)
 
-    @PETSc.Log.EventDecorator()
     @profiler()
     def solve(self, rhs=None):
         """


### PR DESCRIPTION
The event decorator should only be used by setting the `ASQ_PROFILE` environment variable to `PETSC_LOG`. These explicit calls should have been removed in a previous PR but found their way back in when the AAOS refactor was merged.