### PR TITLE
Make setup method on `AllAtOnceMixin` "private"

### DIFF
--- a/asQ/allatonce/form.py
+++ b/asQ/allatonce/form.py
@@ -32,7 +32,7 @@ class AllAtOnceForm(TimePartitionMixin):
         :arg bcs: a list of DirichletBC boundary conditions on aaofunc.field_function_space.
         :arg alpha: float, circulant matrix parameter. if None then no circulant approximation used.
         """
-        self.time_partition_setup(aaofunc.ensemble, aaofunc.time_partition)
+        self._time_partition_setup(aaofunc.ensemble, aaofunc.time_partition)
 
         self.aaofunc = aaofunc
         self.field_function_space = aaofunc.field_function_space

--- a/asQ/allatonce/function.py
+++ b/asQ/allatonce/function.py
@@ -58,7 +58,7 @@ class AllAtOnceFunction(TimePartitionMixin):
             ensemble rank.
         :arg function_space: a FunctionSpace for the solution at a single timestep.
         """
-        self.time_partition_setup(ensemble, time_partition)
+        self._time_partition_setup(ensemble, time_partition)
 
         # function space for single timestep
         self.field_function_space = function_space

--- a/asQ/allatonce/jacobian.py
+++ b/asQ/allatonce/jacobian.py
@@ -43,7 +43,7 @@ class AllAtOnceJacobian(TimePartitionMixin):
         :arg options_prefix: string prefix for the Jacobian PETSc options.
         :arg appctx: the appcontext for the Jacobian and the preconditioner.
         """
-        self.time_partition_setup(aaoform.ensemble, aaoform.time_partition)
+        self._time_partition_setup(aaoform.ensemble, aaoform.time_partition)
         prefix = self.prefix + options_prefix
 
         aaofunc = aaoform.aaofunc

--- a/asQ/allatonce/mixin.py
+++ b/asQ/allatonce/mixin.py
@@ -17,7 +17,7 @@ class TimePartitionMixin(object):
     def __init__(self):
         pass
 
-    def time_partition_setup(self, ensemble, time_partition):
+    def _time_partition_setup(self, ensemble, time_partition):
         """
         Sets the provided member variables. This is not implemented in the
         the __init__ method to accomodate child classes which will be

--- a/asQ/allatonce/solver.py
+++ b/asQ/allatonce/solver.py
@@ -43,7 +43,7 @@ class AllAtOnceSolver(TimePartitionMixin):
         :arg pre_jacobian_callback: As above, but called immediately before Jacobian assembly.
         :arg post_jacobian_callback: As above, but called immediately after Jacobian assembly.
         """
-        self.time_partition_setup(aaofunc.ensemble, aaofunc.time_partition)
+        self._time_partition_setup(aaofunc.ensemble, aaofunc.time_partition)
         self.aaofunc = aaofunc
         self.aaoform = aaoform
 

--- a/asQ/diag_preconditioner.py
+++ b/asQ/diag_preconditioner.py
@@ -97,7 +97,7 @@ class DiagFFTPC(TimePartitionMixin):
         A, _ = pc.getOperators()
         jacobian = A.getPythonContext()
         self.jacobian = jacobian
-        self.time_partition_setup(jacobian.ensemble, jacobian.time_partition)
+        self._time_partition_setup(jacobian.ensemble, jacobian.time_partition)
 
         jacobian.pc = self
         aaofunc = jacobian.current_state

--- a/asQ/paradiag.py
+++ b/asQ/paradiag.py
@@ -90,7 +90,7 @@ class Paradiag(TimePartitionMixin):
         :arg pre_jacobian_callback: As above, but called immediately before Jacobian assembly.
         :arg post_jacobian_callback: As above, but called immediately after Jacobian assembly.
         """
-        self.time_partition_setup(ensemble, time_partition)
+        self._time_partition_setup(ensemble, time_partition)
 
         # all-at-once function and form
 


### PR DESCRIPTION
This setup method should only ever be called once by the child class, and never by a user. The prefix underscore is as close as python gets to enforcing this.