### PR TITLE
Add a test for running asQ serially in time

### DIFF
--- a/asQ/paradiag.py
+++ b/asQ/paradiag.py
@@ -18,7 +18,7 @@ def create_ensemble(time_partition, comm=fd.COMM_WORLD):
     :arg time_partition: a list of integers, the number of timesteps on each time-rank
     :arg comm: the global communicator for the ensemble
     '''
-    nslices = len(time_partition)
+    nslices = 1 if type(time_partition) is int else len(time_partition)
     nranks = comm.size
 
     if nranks % nslices != 0:


### PR DESCRIPTION
This test makes sure that we can run with just a single time-slice.

Running like this reduces the complexity of setting up some new methods so can be useful for trying out new things.
It also means we can possibly make some jupyter notebooks at some point.