### PR TITLE
`ManifoldTransferManager` _is a_ `TransferManager` (i.e. inherits from) instead of _has a_ `TransferManager`

### DIFF
--- a/case_studies/shallow_water/galewsky_comparison.py
+++ b/case_studies/shallow_water/galewsky_comparison.py
@@ -211,8 +211,8 @@ parallel_sparameters['diagfft_block_'] = block_sparameters
 appctx = {}
 transfer_managers = []
 for _ in range(time_partition[ensemble.ensemble_comm.rank]):
-    tm = mg.manifold_transfer_manager(W)
-    transfer_managers.append(tm)
+    transfer_managers.append(mg.ManifoldTransferManager())
+
 appctx['diagfft_transfer_managers'] = transfer_managers
 
 miniapp = ComparisonMiniapp(ensemble, time_partition,
@@ -225,7 +225,7 @@ miniapp = ComparisonMiniapp(ensemble, time_partition,
                             appctx=appctx)
 
 miniapp.serial_app.nlsolver.set_transfer_manager(
-    mg.manifold_transfer_manager(W))
+    mg.ManifoldTransferManager())
 
 rank = ensemble.ensemble_comm.rank
 norm0 = fd.norm(w_initial)

--- a/case_studies/shallow_water/galewsky_serial.py
+++ b/case_studies/shallow_water/galewsky_serial.py
@@ -141,7 +141,7 @@ miniapp = SerialMiniApp(dt, args.theta,
                         sparameters)
 
 miniapp.nlsolver.set_transfer_manager(
-    mg.manifold_transfer_manager(W))
+    mg.ManifoldTransferManager())
 
 potential_vorticity = diagnostics.potential_vorticity_calculator(
     u_initial.function_space(), name='vorticity')

--- a/case_studies/shallow_water/linear_swe_serial.py
+++ b/case_studies/shallow_water/linear_swe_serial.py
@@ -53,7 +53,7 @@ coriolis = case.coriolis_expression(*x)
 
 # initial conditions
 w_initial = fd.Function(W)
-u_initial, h_initial = w_initial.split()
+u_initial, h_initial = w_initial.subfunctions
 
 u_initial.project(case.velocity_expression(*x))
 h_initial.project(case.depth_expression(*x))
@@ -142,8 +142,7 @@ miniapp = SerialMiniApp(dt, args.theta,
                         form_function,
                         sparameters)
 
-miniapp.nlsolver.set_transfer_manager(
-    mg.manifold_transfer_manager(W))
+miniapp.nlsolver.set_transfer_manager(mg.ManifoldTransferManager())
 
 PETSc.Sys.Print('### === --- Timestepping loop --- === ###')
 linear_its = 0
@@ -171,7 +170,7 @@ def postproc(app, step, t):
     linear_its += app.nlsolver.snes.getLinearSolveIterations()
     nonlinear_its += app.nlsolver.snes.getIterationNumber()
 
-    u, h = app.w0.split()
+    u, h = app.w0.subfunctions
     uout.assign(u)
     hout.assign(h-case.H)
     ofile.write(uout, hout, time=t/units.hour)

--- a/case_studies/shallow_water/williamson2.py
+++ b/case_studies/shallow_water/williamson2.py
@@ -193,8 +193,7 @@ appctx = {}
 transfer_managers = []
 nlocal_timesteps = time_partition[ensemble.ensemble_comm.rank]
 for _ in range(nlocal_timesteps):
-    tm = mg.manifold_transfer_manager(W)
-    transfer_managers.append(tm)
+    transfer_managers.append(mg.ManifoldTransferManager())
 
 appctx['diagfft_transfer_managers'] = transfer_managers
 

--- a/tests/test_paradiag.py
+++ b/tests/test_paradiag.py
@@ -343,8 +343,7 @@ def test_galewsky_timeseries():
     appctx = {}
     transfer_managers = []
     for _ in range(time_partition[ensemble.ensemble_comm.rank]):
-        tm = mg.manifold_transfer_manager(W)
-        transfer_managers.append(tm)
+        transfer_managers.append(mg.ManifoldTransferManager())
     appctx['diag_transfer_managers'] = transfer_managers
 
     miniapp = ComparisonMiniapp(ensemble, time_partition,
@@ -356,7 +355,7 @@ def test_galewsky_timeseries():
                                 appctx=appctx)
 
     miniapp.serial_app.nlsolver.set_transfer_manager(
-        mg.manifold_transfer_manager(W))
+        mg.ManifoldTransferManager())
 
     norm0 = fd.norm(w_initial)
 

--- a/utils/shallow_water/miniapp.py
+++ b/utils/shallow_water/miniapp.py
@@ -120,8 +120,7 @@ class ShallowWaterMiniApp(TimePartitionMixin):
         # should look at removing this once the manifold transfer manager has found a proper home
         transfer_managers = []
         for _ in range(self.nlocal_timesteps):
-            tm = mg.manifold_transfer_manager(self.function_space())
-            transfer_managers.append(tm)
+            transfer_managers.append(mg.ManifoldTransferManager())
 
         appctx['diagfft_transfer_managers'] = transfer_managers
 


### PR DESCRIPTION
This tidies up the `ManifoldTransferManager` a bit by making it inherit from `firedrake.TransferManager`. The firedrake manager takes care of transferring mixed spaces, so the code in `manifold_transfer_manager` was redundant.