### PR TITLE
workstealing for ci pytest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,8 +62,8 @@ jobs:
           python --version
           python -m pytest --version
           python -m pytest \
-            -n 6 --dist=worksteal
             --durations=40 \
             --timeout=600 \
             --cov=asQ --cov-report=term \
+            -n 6 --dist=worksteal
             -v tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,4 +61,9 @@ jobs:
           . /home/firedrake/firedrake/bin/activate
           python --version
           python -m pytest --version
-          python -m pytest -v -n 6 --durations=40 --timeout=600 --cov=asQ --cov-report=term tests/
+          python -m pytest \
+            -n 6 --dist=worksteal
+            --durations=40 \
+            --timeout=600 \
+            --cov=asQ --cov-report=term \
+            -v tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,5 +65,5 @@ jobs:
             --durations=40 \
             --timeout=600 \
             --cov=asQ --cov-report=term \
-            -n 6 --dist=worksteal
+            -n 6 --dist=worksteal \
             -v tests/


### PR DESCRIPTION
Some of our tests take less than a second, some take several minutes. This should speed up the CI slightly by allowing pytest worker threads to steal tests from other workers.