### PR TITLE
Pass a tuple of `Constants` to complex_proxy for the complex coefficients

### DIFF
--- a/asQ/complex_proxy/common.py
+++ b/asQ/complex_proxy/common.py
@@ -53,10 +53,6 @@ def _complex_components(z):
     Return zr and zi for z if z is either complex or ComplexTuple
     """
     def is_complex_tuple(z):
-        # is_pair = isinstance(z, tuple) and len(z) == 2
-        # constant_components = all(isinstance(cmpnt, Constant) for cmpnt in z)
-        # return is_pair and constant_components
-
         return (isinstance(z, tuple)
                 and len(z) == 2
                 and all(isinstance(cmpnt, Constant) for cmpnt in z))

--- a/asQ/complex_proxy/mixed_impl.py
+++ b/asQ/complex_proxy/mixed_impl.py
@@ -2,8 +2,9 @@
 import firedrake as fd
 
 from asQ.complex_proxy.common import (Part, re, im, api_names,  # noqa:F401
+                                      ComplexConstant,  # noqa: F401
                                       _flatten_tree,
-                                      _build_oneform, _build_twoform)  # noqa: F401
+                                      _build_oneform, _build_twoform)
 
 from asQ.profiling import profiler
 

--- a/asQ/complex_proxy/vector_impl.py
+++ b/asQ/complex_proxy/vector_impl.py
@@ -4,7 +4,8 @@ import firedrake as fd
 from ufl.classes import MultiIndex, FixedIndex, Indexed
 
 from asQ.complex_proxy.common import (Part, re, im, api_names,  # noqa:F401
-                                      _build_oneform, _build_twoform)  # noqa: F401
+                                      ComplexConstant,  # noqa: F401
+                                      _build_oneform, _build_twoform)
 
 from asQ.profiling import profiler
 

--- a/tests/complex_proxy/test_complex_mixed.py
+++ b/tests/complex_proxy/test_complex_mixed.py
@@ -31,6 +31,11 @@ elements = scalar_elements + vector_elements + tensor_elements
 
 complex_numbers = [2+0j, 0+3j, 3+2j]
 
+constant_z = [
+    pytest.param(False, id="complex_z"),
+    pytest.param(True, id="Constant_z"),
+]
+
 
 @pytest.fixture
 def nx():
@@ -249,13 +254,17 @@ def test_mixed_set_get_part(mesh):
 
 @pytest.mark.parametrize("elem", scalar_elements+vector_elements)
 @pytest.mark.parametrize("z", complex_numbers)
-def test_linear_form(mesh, elem, z):
+@pytest.mark.parametrize("z_is_constant", constant_z)
+def test_linear_form(mesh, elem, z, z_is_constant):
     """
     Test that the linear Form is constructed correctly
 
     TODO: add tests for tensor_elements
     """
     eps = 1e-12
+
+    if z_is_constant:
+        z = cpx.ComplexConstant(z)
 
     V = fd.FunctionSpace(mesh, elem)
     W = cpx.FunctionSpace(V)
@@ -291,7 +300,8 @@ def test_linear_form(mesh, elem, z):
 
 
 @pytest.mark.parametrize("elem", scalar_elements+vector_elements)
-def test_bilinear_form(mesh, elem):
+@pytest.mark.parametrize("z_is_constant", constant_z)
+def test_bilinear_form(mesh, elem, z_is_constant):
     """
     Test that the bilinear form is constructed correctly
 
@@ -339,6 +349,9 @@ def test_bilinear_form(mesh, elem):
 
     # non-zero only on diagonal blocks: real and imag parts independent
     zr = 3+0j
+    if z_is_constant:
+        zr = cpx.ComplexConstant(zr)
+
     K = cpx.BilinearForm(W, zr, form_function)
     wr = assemble(fd.action(K, g))
 
@@ -350,6 +363,8 @@ def test_bilinear_form(mesh, elem):
 
     # non-zero only on off-diagonal blocks: real and imag parts independent
     zi = 0+4j
+    if z_is_constant:
+        zi = cpx.ComplexConstant(zi)
 
     K = cpx.BilinearForm(W, zi, form_function)
     wi = assemble(fd.action(K, g))
@@ -361,7 +376,10 @@ def test_bilinear_form(mesh, elem):
     assert fd.errornorm(4*1*b, bi) < 1e-12
 
     # non-zero in all blocks:
-    z = zr + zi
+    if not z_is_constant:
+        z = zr + zi
+    else:
+        z = cpx.ComplexConstant(zr.real, zi.imag)
 
     K = cpx.BilinearForm(W, z, form_function)
     wz = assemble(fd.action(K, g))


### PR DESCRIPTION
This means that we can change the values of the coefficients later on by modifying the `Constant`.
This was already possible where you have direct access to the `BilinearForm` call, but not when this call was hidden further down the stack - e.g. inside the `AuxiliaryBlockPC`.