### PR TITLE
Update state of aaofunc._vec when underlying data is changed

### DIFF
--- a/asQ/allatonce/function.py
+++ b/asQ/allatonce/function.py
@@ -467,6 +467,7 @@ class AllAtOnceFunction(TimePartitionMixin):
         # manager to make sure that the data gets copied to/from the
         # Function.dat storage and _vec.
         with self.function.dat.vec:
+            self._vec.stateIncrease()
             yield self._vec
 
     @contextlib.contextmanager
@@ -481,6 +482,7 @@ class AllAtOnceFunction(TimePartitionMixin):
         # manager to make sure that the data gets copied into _vec from
         # the Function.dat storage.
         with self.function.dat.vec_ro:
+            self._vec.stateIncrease()
             yield self._vec
 
     @contextlib.contextmanager


### PR DESCRIPTION
PETSc keeps track of the "state" of `Vecs` i.e. how often the `Vec` has been modified,  so it can stash calculations (e.g. norms) and reuse them if the data hasn't changed.

The all-at-once `Vec` in the `AllAtOnceFunction` just "views" the storage buffer in the `Vec` in `aaofunc.function`, the `firedrake.Function` for the all-at-once mixed space. The `AllAtOnceFunction` context managers for `aaofunc._vec`  update the values in the `aaofunc._vec` by updating the values in the `aaofunc.function.dat.vec` using the usual Firedrake context managers.
This means that the data of the `aaofunc._vec` is updated without `aaofunc._vec` getting called directly, so the state isn't increased. PETSc then incorrectly thinks that it can reuse previously calculated values.

This PR just increments the state manually when the data in the `aaofunc._vec` is updated.