### PR TITLE
Stop the SWE test writing a vtk file

### DIFF
--- a/tests/test_paradiag.py
+++ b/tests/test_paradiag.py
@@ -449,7 +449,8 @@ def test_steady_swe_miniapp():
         create_mesh=create_mesh,
         dt=dt, theta=theta,
         time_partition=time_partition,
-        paradiag_sparameters=solver_parameters_diag)
+        paradiag_sparameters=solver_parameters_diag,
+        record_diagnostics={'cfl': True, 'file': False})
 
     miniapp.solve()
     pdg = miniapp.paradiag


### PR DESCRIPTION
This  file currently gets written to the base directory every time the tests are run. This PR stops the tests creating new files.