### PR TITLE
Update use of `firedrake.interpolate` with new symbolic version

### DIFF
--- a/case_studies/stratigraphic_model/mms.py
+++ b/case_studies/stratigraphic_model/mms.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
 
         for i in range(1):
             t.assign(t+dt)
-            s_exact = fd.interpolate((t+1)*fd.sin((x+2*y)), Z)
+            s_exact = fd.Function(Z).interpolate((t+1)*fd.sin((x+2*y)))
             solver.solve()
             A = fd.errornorm(s, s_exact)/fd.norm(s_exact)
             PETSc.Sys.Print("E :%s" % A)

--- a/utils/mg.py
+++ b/utils/mg.py
@@ -53,7 +53,7 @@ def high_order_icosahedral_mesh_hierarchy(mh, degree, R0):
     meshes = []
     for m in mh:
         X = fd.VectorFunctionSpace(m, "Lagrange", degree)
-        new_coords = fd.interpolate(m.coordinates, X)
+        new_coords = fd.Function(X).interpolate(m.coordinates)
         x, y, z = new_coords
         r = (x**2 + y**2 + z**2)**0.5
         new_coords.interpolate(R0*new_coords/r)

--- a/utils/shallow_water/galewsky.py
+++ b/utils/shallow_water/galewsky.py
@@ -123,7 +123,7 @@ def depth_expression(x, y, z):
     W = fd.VectorFunctionSpace(mesh, V.ufl_element())
 
     # initialise depth from coordinates
-    coords = fd.interpolate(mesh.coordinates, W)
+    coords = fd.Function(W).interpolate(mesh.coordinates)
     h = fd.Function(V)
     h.dat.data[:] = depth_calculation(coords.dat.data_ro)
 


### PR DESCRIPTION
`firedrake.interpolate(expr, V)` recently changed to return a symbolic expression instead of a `Function` (see Firedrake PR #2297). This was raising a load of deprecation warnings if using it in the "old" style.

This PR just updates all instances of `u = fd.interpolate(expr, V)` to `u = fd.Function(V).interpolate(expr)`.