### PR TITLE
Set multigrid transfer managers using petsc options

### DIFF
--- a/asQ/diag_preconditioner.py
+++ b/asQ/diag_preconditioner.py
@@ -366,15 +366,6 @@ class DiagFFTPC(TimePartitionMixin):
             block_solver = fd.LinearVariationalSolver(block_problem,
                                                       appctx=appctx_h,
                                                       options_prefix=block_prefix)
-            # multigrid transfer manager
-            if f'{self.prefix}transfer_managers' in appctx:
-                # block_solver.set_transfer_manager(jacobian.appctx['diagfft_transfer_managers'][ii])
-                tm = appctx[f'{self.prefix}transfer_managers'][i]
-                block_solver.set_transfer_manager(tm)
-                tm_set = (block_solver._ctx.transfer_manager is tm)
-
-                if tm_set is False:
-                    print(f"transfer manager not set on block_solvers[{ii}]")
 
             self.block_solvers.append(block_solver)
 

--- a/case_studies/shallow_water/galewsky.py
+++ b/case_studies/shallow_water/galewsky.py
@@ -66,7 +66,9 @@ patch_parameters = {
     }
 }
 
+from utils.mg import ManifoldTransferManager  # noqa: F401
 mg_parameters = {
+    'transfer_manager': f'{__name__}.ManifoldTransferManager',
     'levels': {
         'ksp_type': 'gmres',
         'ksp_max_it': 5,

--- a/case_studies/shallow_water/galewsky_comparison.py
+++ b/case_studies/shallow_water/galewsky_comparison.py
@@ -89,6 +89,7 @@ def form_mass(u, h, v, q):
 
 
 # solver parameters for the implicit solve
+from utils.mg import ManifoldTransferManager  # noqa: F401
 atol = 1e4
 serial_sparameters = {
     'snes': {
@@ -108,6 +109,7 @@ serial_sparameters = {
     'pc_mg_cycle_type': 'w',
     'pc_mg_type': 'multiplicative',
     'mg': {
+        'transfer_manager': f'{__name__}.ManifoldTransferManager',
         'levels': {
             'ksp_type': 'gmres',
             'ksp_max_it': 5,
@@ -154,6 +156,7 @@ block_sparameters = {
     'pc_mg_cycle_type': 'v',
     'pc_mg_type': 'multiplicative',
     'mg': {
+        'transfer_manager': f'{__name__}.ManifoldTransferManager',
         'levels': {
             'ksp_type': 'gmres',
             'ksp_max_it': 5,

--- a/case_studies/shallow_water/galewsky_serial.py
+++ b/case_studies/shallow_water/galewsky_serial.py
@@ -84,6 +84,7 @@ def form_mass(u, h, v, q):
 
 
 # solver parameters for the implicit solve
+from utils.mg import ManifoldTransferManager  # noqa: F401
 sparameters = {
     'snes': {
         'monitor': None,
@@ -105,6 +106,7 @@ sparameters = {
     'pc_mg_cycle_type': 'w',
     'pc_mg_type': 'multiplicative',
     'mg': {
+        'transfer_manager': f'{__name__}.ManifoldTransferManager',
         'levels': {
             'ksp_type': 'gmres',
             'ksp_max_it': 5,

--- a/case_studies/shallow_water/linear_gravity_bumps.py
+++ b/case_studies/shallow_water/linear_gravity_bumps.py
@@ -65,7 +65,9 @@ patch_parameters = {
     }
 }
 
+from utils.mg import ManifoldTransferManager  # noqa: F401
 mg_parameters = {
+    'transfer_manager': f'{__name__}.ManifoldTransferManager',
     'levels': {
         'ksp_type': 'gmres',
         'ksp_max_it': 5,

--- a/case_studies/shallow_water/linear_swe_serial.py
+++ b/case_studies/shallow_water/linear_swe_serial.py
@@ -94,7 +94,9 @@ patch_parameters = {
     }
 }
 
+from utils.mg import ManifoldTransferManager  # noqa: F401
 mg_parameters = {
+    'transfer_manager': f'{__name__}.ManifoldTransferManager',
     'levels': {
         'ksp_type': 'gmres',
         'ksp_max_it': 5,

--- a/case_studies/shallow_water/williamson2.py
+++ b/case_studies/shallow_water/williamson2.py
@@ -114,7 +114,9 @@ patch_parameters = {
     }
 }
 
+from utils.mg import ManifoldTransferManager  # noqa: F401
 mg_parameters = {
+    'transfer_manager': f'{__name__}.ManifoldTransferManager',
     'levels': {
         'ksp_type': 'gmres',
         'ksp_max_it': 5,

--- a/case_studies/shallow_water/williamson5.py
+++ b/case_studies/shallow_water/williamson5.py
@@ -61,7 +61,9 @@ patch_parameters = {
     }
 }
 
+from utils.mg import ManifoldTransferManager  # noqa: F401
 mg_parameters = {
+    'transfer_manager': f'{__name__}.ManifoldTransferManager',
     'levels': {
         'ksp_type': 'gmres',
         'ksp_max_it': 5,

--- a/case_studies/shallow_water/williamson5_verify.py
+++ b/case_studies/shallow_water/williamson5_verify.py
@@ -43,6 +43,7 @@ ensemble = fd.Ensemble(fd.COMM_WORLD, args.nspatial_domains)
 trank = ensemble.ensemble_comm.rank
 
 # block solver options
+from utils.mg import ManifoldTransferManager  # noqa: F401
 sparameters = {
     "snes_atol": 1e-8,
     "mat_type": "matfree",
@@ -52,6 +53,7 @@ sparameters = {
     "pc_type": "mg",
     "pc_mg_cycle_type": "v",
     "pc_mg_type": "multiplicative",
+    'mg_transfer_manager': f'{__name__}.ManifoldTransferManager',
     "mg_levels_ksp_type": "gmres",
     "mg_levels_ksp_max_it": 3,
     "mg_levels_pc_type": "python",

--- a/tests/test_paradiag.py
+++ b/tests/test_paradiag.py
@@ -272,7 +272,9 @@ def test_galewsky_timeseries():
     }
 
     # mg with patch smoother
+    from utils.mg import ManifoldTransferManager  # noqa: F401
     mg_parameters = {
+        'transfer_manager': f'{__name__}.ManifoldTransferManager',
         'levels': {
             'ksp_type': 'gmres',
             'ksp_max_it': 5,
@@ -414,7 +416,10 @@ def test_steady_swe_miniapp():
     sparameters = {
         'ksp_type': 'preonly',
         'pc_type': 'lu',
-        'pc_factor_mat_solver_type': 'mumps'}
+        'pc_factor_mat_solver_type': 'mumps',
+        'pc_factor_reuse_fill': None,
+        'pc_factor_reuse_ordering': None,
+    }
 
     solver_parameters_diag = {
         "snes_linesearch_type": "basic",
@@ -430,7 +435,7 @@ def test_steady_swe_miniapp():
         'pc_python_type': 'asQ.DiagFFTPC',
         'aaos_jacobian_state': 'initial',
         'diagfft_state': 'initial',
-        'diagfft_alpha': 1e-3,
+        'diagfft_alpha': 1e-5,
     }
 
     for i in range(sum(time_partition)):

--- a/tests/test_paradiag.py
+++ b/tests/test_paradiag.py
@@ -5,6 +5,12 @@ from firedrake.petsc import PETSc
 from functools import reduce, partial
 from operator import mul
 
+# This hack is here because firedrake can't import from double-qualified
+# modules so passing 'utils.mg.ManifoldTransferManager' in the petsc
+# options results in an error. Instead we import the tm here and pass
+# '{__name__}.ManifoldTransferManager'
+from utils.mg import ManifoldTransferManager  # noqa: F401
+
 
 @pytest.mark.parallel(nprocs=4)
 def test_Nitsche_BCs():
@@ -272,7 +278,6 @@ def test_galewsky_timeseries():
     }
 
     # mg with patch smoother
-    from utils.mg import ManifoldTransferManager  # noqa: F401
     mg_parameters = {
         'transfer_manager': f'{__name__}.ManifoldTransferManager',
         'levels': {

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,9 +1,9 @@
 import utils.units  # noqa: F401
 import utils.planets  # noqa: F401
+import utils.mg  # noqa: F401
 import utils.shallow_water  # noqa: F401
 import utils.compressible_flow  # noqa: F401
 import utils.vertical_slice  # noqa: F401
-import utils.mg  # noqa: F401
 import utils.diagnostics  # noqa: F401
 import utils.timing  # noqa: F401
 import utils.serial  # noqa: F401

--- a/utils/shallow_water/miniapp.py
+++ b/utils/shallow_water/miniapp.py
@@ -5,7 +5,6 @@ from asQ.allatonce.mixin import TimePartitionMixin
 from utils import units
 from utils import diagnostics
 import utils.shallow_water as swe
-from utils import mg
 
 
 class ShallowWaterMiniApp(TimePartitionMixin):
@@ -112,17 +111,6 @@ class ShallowWaterMiniApp(TimePartitionMixin):
             reference_state = self.reference_state
         else:
             reference_state = None
-
-        # non-petsc information for block solve
-
-        # mesh transfer operators
-        # probably shouldn't be here, but has to be at the moment because we can't get at the mesh to make W before initialising.
-        # should look at removing this once the manifold transfer manager has found a proper home
-        transfer_managers = []
-        for _ in range(self.nlocal_timesteps):
-            transfer_managers.append(mg.ManifoldTransferManager())
-
-        appctx['diagfft_transfer_managers'] = transfer_managers
 
         self.paradiag = asQ.Paradiag(
             ensemble=self.ensemble,


### PR DESCRIPTION
We used to have to manually construct multigrid transfer managers by creating a `ManifoldTransferManager` and using the restrict/inject/prolong methods of that object to construct a `firedrake.TransferManager`. This meant that we couldn't just use the default constructor.

The `ManifoldTransferManager` has been refactored so we can now just use the default constructor. This means we can set the transfer manager for the blocks just using petsc options, similarly to setting python preconditioners. The explicit handling of transfer managers in the shallow water miniapp and in the circulant preconditioner can be removed.