### PR TITLE
deprecate `'diagfft'` prefix for `CirculantPC`

### DIFF
--- a/asQ/allatonce/jacobian.py
+++ b/asQ/allatonce/jacobian.py
@@ -1,8 +1,6 @@
 import firedrake as fd
 from firedrake.petsc import PETSc
 
-from functools import partial
-
 from asQ.profiling import profiler
 from asQ.common import get_option_from_list
 from asQ.allatonce.mixin import TimePartitionMixin
@@ -84,11 +82,8 @@ class AllAtOnceJacobian(TimePartitionMixin):
         if (prefix != "") and (not prefix.endswith("_")):
             prefix += "_"
 
-        state_option = f"{prefix}state"
-
-        self.jacobian_state = partial(get_option_from_list,
-                                      state_option, valid_jacobian_states,
-                                      default_index=0)
+        self.jacobian_state = get_option_from_list(
+            prefix, "state", valid_jacobian_states, default_index=0)
 
         if reference_state is not None:
             self.reference_state = fd.Function(aaofunc.field_function_space)
@@ -96,9 +91,7 @@ class AllAtOnceJacobian(TimePartitionMixin):
         else:
             self.reference_state = None
 
-        jacobian_state = self.jacobian_state()
-
-        if jacobian_state == 'reference' and self.reference_state is None:
+        if self.jacobian_state == 'reference' and self.reference_state is None:
             raise ValueError("AllAtOnceJacobian must be provided a reference state to use \'reference\' for aaos_jacobian_state.")
 
         self.update()
@@ -113,7 +106,7 @@ class AllAtOnceJacobian(TimePartitionMixin):
         """
 
         aaofunc = self.aaofunc
-        jacobian_state = self.jacobian_state()
+        jacobian_state = self.jacobian_state
 
         if jacobian_state in ('linear', 'user'):
             return

--- a/tests/test_paradiag.py
+++ b/tests/test_paradiag.py
@@ -53,7 +53,7 @@ def test_Nitsche_BCs():
     }
 
     M = [2, 2]
-    solver_parameters_diag["diagfft_block_"] = sparameters
+    solver_parameters_diag["circulant_block_"] = sparameters
 
     theta = 0.5
 
@@ -157,7 +157,7 @@ def test_Nitsche_heat_timeseries():
     }
 
     for i in range(sum(time_partition)):
-        parallel_sparameters['diagfft_block_'+str(i)] = block_sparameters
+        parallel_sparameters['circulant_block_'+str(i)] = block_sparameters
     appctx = {}
 
     miniapp = ComparisonMiniapp(ensemble, time_partition,
@@ -341,11 +341,11 @@ def test_galewsky_timeseries():
         },
         'pc_type': 'python',
         'pc_python_type': 'asQ.CirculantPC',
-        'diagfft_alpha': 1e-3,
+        'circulant_alpha': 1e-3,
     }
 
     for i in range(sum(time_partition)):
-        parallel_sparameters['diagfft_block_'+str(i)] = block_sparameters
+        parallel_sparameters['circulant_block_'+str(i)] = block_sparameters
 
     appctx = {}
     transfer_managers = []
@@ -439,12 +439,12 @@ def test_steady_swe_miniapp():
         'pc_type': 'python',
         'pc_python_type': 'asQ.CirculantPC',
         'aaos_jacobian_state': 'initial',
-        'diagfft_state': 'initial',
-        'diagfft_alpha': 1e-5,
+        'circulant_state': 'initial',
+        'circulant_alpha': 1e-5,
     }
 
     for i in range(sum(time_partition)):
-        solver_parameters_diag["diagfft_block_"+str(i)] = sparameters
+        solver_parameters_diag["circulant_block_"+str(i)] = sparameters
 
     dt = 0.2*units.hour
 
@@ -551,7 +551,7 @@ def test_solve_para_form(bc_opt, extruded):
     }
 
     for i in range(ntimesteps):
-        solver_parameters_diag[f"diagfft_block_{i}_"] = sparameters
+        solver_parameters_diag[f"circulant_block_{i}_"] = sparameters
 
     def form_function(u, v, t):
         return fd.inner((1.+c*fd.inner(u, u))*fd.grad(u), fd.grad(v))*fd.dx
@@ -633,11 +633,11 @@ def test_diagnostics():
         'ksp_type': 'preonly',
         'pc_type': 'python',
         'pc_python_type': 'asQ.CirculantPC',
-        'diagfft_alpha': 1e-3,
+        'circulant_alpha': 1e-3,
     }
 
     for i in range(sum(time_partition)):
-        diag_sparameters["diagfft_block_" + str(i) + "_"] = block_sparameters
+        diag_sparameters["circulant_block_" + str(i) + "_"] = block_sparameters
 
     def form_function(u, v, t):
         return fd.inner(fd.grad(u), fd.grad(v))*fd.dx


### PR DESCRIPTION
Deprecates the `'diagfft'` prefix for the circulant preconditioner and replaces it with `'circulant'`.