### PR TITLE
change explicit lambdas in default args to None

### DIFF
--- a/asQ/allatonce/solver.py
+++ b/asQ/allatonce/solver.py
@@ -16,10 +16,10 @@ class AllAtOnceSolver(TimePartitionMixin):
                  options_prefix="",
                  jacobian_form=None,
                  jacobian_reference_state=None,
-                 pre_function_callback=lambda solver, X: None,
-                 post_function_callback=lambda solver, X, F: None,
-                 pre_jacobian_callback=lambda solver, X, J: None,
-                 post_jacobian_callback=lambda solver, X, J: None):
+                 pre_function_callback=None,
+                 post_function_callback=None,
+                 pre_jacobian_callback=None,
+                 post_jacobian_callback=None):
         """
         Solve an all-at-once form over an all-at-once function.
 

--- a/asQ/paradiag.py
+++ b/asQ/paradiag.py
@@ -153,12 +153,9 @@ class Paradiag(TimePartitionMixin):
             self.block_iterations.data(deepcopy=False)[:] = pc_block_iterations.data(deepcopy=False)
 
     @profiler()
-    def solve(self,
-              nwindows=1,
-              preproc=lambda pdg, w, rhs: None,
-              postproc=lambda pdg, w, rhs: None,
-              rhs=None,
-              verbose=False):
+    def solve(self, nwindows=1,
+              preproc=None, postproc=None,
+              rhs=None, verbose=False):
         """
         Solve multiple windows of the all-at-once system.
 
@@ -169,6 +166,13 @@ class Paradiag(TimePartitionMixin):
         :arg preproc: callback called before each window solve
         :arg postproc: callback called after each window solve
         """
+        def passthrough(*args, **kwargs):
+            pass
+
+        if preproc is None:
+            preproc = passthrough
+        if postproc is None:
+            postproc = passthrough
 
         for wndw in range(nwindows):
 

--- a/examples/heat/heat_minimal.py
+++ b/examples/heat/heat_minimal.py
@@ -1,7 +1,7 @@
 from firedrake import *
 import asQ
 
-time_partition = [2]
+time_partition = [4, 4]
 ensemble = asQ.create_ensemble(time_partition)
 
 mesh = SquareMesh(nx=8, ny=8, L=1,
@@ -22,25 +22,20 @@ def form_function(u, v, t):
 
 
 block_parameters = {
-    'ksp_view': None,
     'ksp_type': 'preonly',
-    'pc_type': 'jacobi'}
+    'pc_type': 'lu'}
 
 solver_parameters = {
     'ksp_monitor': None,
     'ksp_converged_rate': None,
     'snes_type': 'ksponly',
     'mat_type': 'matfree',
-    'ksp_type': 'preonly',
+    'ksp_type': 'gmres',
     'pc_type': 'python',
-    'pc_python_type': 'asQ.CirculantPC',
-    'circulant_alpha': 1e-10,
-    'circulant_block': block_parameters,
-    'diagfft_state': 'linear',
+    'pc_python_type': 'asQ.JacobiPC',
+    'aaojacobi_block': block_parameters,
+    'aaojacobi_state': 'linear',
     'aaos_jacobian_state': 'linear'}
-
-for i in range(sum(time_partition)):
-    solver_parameters[f'diagfft_block_{i}'] = block_parameters
 
 paradiag = asQ.Paradiag(
     ensemble=ensemble,

--- a/examples/heat/heat_minimal.py
+++ b/examples/heat/heat_minimal.py
@@ -1,7 +1,7 @@
 from firedrake import *
 import asQ
 
-time_partition = [4, 4]
+time_partition = [2]
 ensemble = asQ.create_ensemble(time_partition)
 
 mesh = SquareMesh(nx=8, ny=8, L=1,
@@ -22,20 +22,25 @@ def form_function(u, v, t):
 
 
 block_parameters = {
+    'ksp_view': None,
     'ksp_type': 'preonly',
-    'pc_type': 'lu'}
+    'pc_type': 'jacobi'}
 
 solver_parameters = {
     'ksp_monitor': None,
     'ksp_converged_rate': None,
     'snes_type': 'ksponly',
     'mat_type': 'matfree',
-    'ksp_type': 'gmres',
+    'ksp_type': 'preonly',
     'pc_type': 'python',
-    'pc_python_type': 'asQ.JacobiPC',
-    'aaojacobi_block': block_parameters,
-    'aaojacobi_state': 'linear',
+    'pc_python_type': 'asQ.CirculantPC',
+    'circulant_alpha': 1e-10,
+    'circulant_block': block_parameters,
+    'diagfft_state': 'linear',
     'aaos_jacobian_state': 'linear'}
+
+for i in range(sum(time_partition)):
+    solver_parameters[f'diagfft_block_{i}'] = block_parameters
 
 paradiag = asQ.Paradiag(
     ensemble=ensemble,

--- a/utils/serial/miniapp.py
+++ b/utils/serial/miniapp.py
@@ -68,12 +68,18 @@ class SerialMiniApp(object):
 
         return dt1*dqdt + L
 
-    def solve(self, nt,
-              preproc=lambda miniapp, it, t: None,
-              postproc=lambda miniapp, it, t: None):
+    def solve(self, nt, preproc=None, postproc=None):
         '''
         Integrate forward nt timesteps
         '''
+        def passthrough(*args, **kwargs):
+            pass
+
+        if preproc is None:
+            preproc = passthrough
+        if postproc is None:
+            postproc = passthrough
+
         for step in range(nt):
             preproc(self, step, float(self.time))
             self.nlsolver.solve()


### PR DESCRIPTION
Many of the callbacks have lambdas as default args, but these look terrible with pydoc (and probably with other doc rendering), making the function signature hard to read.

This PR replaces the default arguments with `None` and reassigns the callbacks to a do-nothing function if they aren't given.