### PR TITLE
Use the firedrake docker container with asQ installed for the CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: self-hosted
     # The docker container to use.
     container:
-      image: firedrakeproject/firedrake-vanilla:latest
+      image: firedrakeproject/firedrake:latest
     env:
       ASQ_CI_TESTS: 1
       OMP_NUM_THREADS: 1
@@ -46,11 +46,6 @@ jobs:
           . /home/firedrake/firedrake/bin/activate
           python -m pip install pytest-timeout
           python -m pip install pytest-cov
-      - name: Install
-        run: |
-          . /home/firedrake/firedrake/bin/activate
-          firedrake-status
-          python -m pip install -e .
       - name: Lint
         run: |
           . /home/firedrake/firedrake/bin/activate
@@ -61,4 +56,5 @@ jobs:
           . /home/firedrake/firedrake/bin/activate
           python --version
           python -m pytest --version
+          firedrake-status
           python -m pytest -v -n 6 --durations=40 --timeout=600 --cov=asQ --cov-report=term tests/


### PR DESCRIPTION
asQ can now be installed as part of a Firedrake installation, so it is included in one of the Docker containers built by the Firedrake CI.

We can just use this docker container in our CI rather than using the vanilla docker container and manually installing asQ.