### PR TITLE
`AuxiliaryRealBlockPC` and `AuxiliaryComplexBlockPC`

### DIFF
--- a/asQ/preconditioners/__init__.py
+++ b/asQ/preconditioners/__init__.py
@@ -1,2 +1,3 @@
 from asQ.preconditioners.circulantpc import *  # noqa F401
 from asQ.preconditioners.jacobipc import *  # noqa F401
+from asQ.preconditioners.auxiliary_blockpc import *  # noqa F401

--- a/asQ/preconditioners/auxiliary_blockpc.py
+++ b/asQ/preconditioners/auxiliary_blockpc.py
@@ -69,13 +69,13 @@ class AuxiliaryRealBlockPC(AuxiliaryBlockPCBase):
         us = fd.split(self.uref)
         vs = fd.split(v)
 
-        M = self.form_mass(*us, *vs)
+        dt1 = fd.Constant(1/dt)
+        thet = fd.Constant(theta)
+
+        M = self.form_mass(*fd.split(u), *vs)
 
         F = self.form_function(*us, *vs, self.tref)
         K = fd.derivative(F, self.uref)
-
-        dt1 = fd.Constant(1/dt)
-        thet = fd.Constant(theta)
 
         a = dt1*M + thet*K
 

--- a/asQ/preconditioners/auxiliary_blockpc.py
+++ b/asQ/preconditioners/auxiliary_blockpc.py
@@ -11,7 +11,7 @@ class AuxiliaryBlockPCBase(fd.AuxiliaryOperatorPC):
         appctx = self.get_appctx(pc)
         self.appctx = appctx
 
-        self.prefix = pc.getOptionsPrefix() + self.prefix
+        self.prefix = pc.getOptionsPrefix() + self._prefix
         self.options = PETSc.Options(self.prefix)
 
         self.uref = appctx.get('uref')
@@ -69,7 +69,7 @@ class AuxiliaryRealBlockPC(AuxiliaryBlockPCBase):
         return (a, self.bcs)
 
 
-class AuxiliaryComplexBlockPC(fd.AuxiliaryOperatorPC):
+class AuxiliaryComplexBlockPC(AuxiliaryBlockPCBase):
     """
     A preconditioner for the complex blocks that builds a PC using a specified form.
 
@@ -100,8 +100,8 @@ class AuxiliaryComplexBlockPC(fd.AuxiliaryOperatorPC):
         d1r = self.options.getReal('d1r', default=d1.real)
         d1i = self.options.getReal('d1i', default=d1.imag)
 
-        d2r = self.options.getReal('d2r', default=d1.real)
-        d2i = self.options.getReal('d2i', default=d1.imag)
+        d2r = self.options.getReal('d2r', default=d2.real)
+        d2i = self.options.getReal('d2i', default=d2.imag)
 
         d1 = complex(d1r, d1i)
         d2 = complex(d2r, d2i)

--- a/asQ/preconditioners/auxiliary_blockpc.py
+++ b/asQ/preconditioners/auxiliary_blockpc.py
@@ -1,0 +1,116 @@
+import firedrake as fd
+from firedrake.petsc import PETSc
+
+from functools import partial
+
+__all__ = ['AuxiliaryRealBlockPC', 'AuxiliaryComplexBlockPC']
+
+
+class AuxiliaryBlockPCBase(fd.AuxiliaryOperatorPC):
+    def _setup(self, pc, v, u):
+        appctx = self.get_appctx(pc)
+
+        self.prefix = pc.getOptionsPrefix() + self.prefix
+        self.options = PETSc.Options(self.prefix)
+
+        self.uref = appctx.get('uref')
+        assert self.uref.function_space() == u.function_space()
+
+        self.bcs = appctx['bcs']
+        self.tref = appctx['tref']
+
+        form_mass = appctx['form_mass']
+        form_function = appctx['form_function']
+
+        self.form_mass = appctx.get('aux_form_mass', form_mass)
+        self.form_function = appctx.get('aux_form_function', form_function)
+
+
+class AuxiliaryRealBlockPC(AuxiliaryBlockPCBase):
+    """
+    A preconditioner for the serial-in-time problem that builds a PC using a specified form.
+
+    This preconditioner is analogous to firedrake.AuxiliaryOperatorPC. Given
+    `form_mass` and `form_function` functions (with the usual call-signatures),
+    it constructs an AuxiliaryOperatorPC.
+
+    By default, the timestep, theta parameter, and the form_mass and form_function
+    of the original problem are used (i.e. exactly the same operator as the Jacobian).
+
+    User-defined `form_mass` and `form_function` functions and dt and theta can be
+    passed through the appctx using the following keys:
+        'aux_form_mass': function used to build the mass matrix.
+        'aux_form_function': function used to build the stiffness matrix.
+        'aux_dt': timestep size.
+        'aux_theta': implicit theta parameter.
+    """
+    def form(self, pc, v, u):
+        self._setup(pc, v, u)
+
+        appctx = self.get_appctx(pc)
+
+        dt = appctx['dt']
+        theta = appctx['theta']
+
+        dt = self.options.getReal('dt', default=dt)
+        theta = self.options.getReal('theta', default=theta)
+
+        us = fd.split(self.uref)
+        vs = fd.split(v)
+
+        M = self.form_mass(*us, *vs)
+        K = self.form_function(*us, *vs, self.tref)
+
+        dt1 = fd.Constant(1/dt)
+        thet = fd.Constant(theta)
+
+        F = dt1*M + thet*K
+        a = fd.derivative(F, self.uref)
+
+        return (a, self.bcs)
+
+
+class AuxiliaryComplexBlockPC(fd.AuxiliaryOperatorPC):
+    """
+    A preconditioner for the complex blocks that builds a PC using a specified form.
+
+    This preconditioner is analogous to firedrake.AuxiliaryOperatorPC. Given
+    `form_mass` and `form_function` functions on the real function space (with the
+    usual call-signatures), it constructs an AuxiliaryOperatorPC on the complex
+    block function space.
+
+    By default, the circulant eigenvalues and the form_mass and form_function of the
+    circulant preconditioner are used (i.e. exactly the same operator as the block).
+
+    User-defined `form_mass` and `form_function` functions and complex coeffiecients
+    can be passed through the block_appctx using the following keys:
+        'aux_form_mass': function used to build the mass matrix.
+        'aux_form_function': function used to build the stiffness matrix.
+        'aux_%d_d1': complex coefficient on the mass matrix of the %d'th block.
+        'aux_%d_d2': complex coefficient on the stiffness matrix of the %d'th block.
+    """
+    def form(self, pc, v, u):
+        appctx = self.get_appctx(pc)
+
+        cpx = appctx['cpx']
+
+        d1 = appctx['d1']
+        d2 = appctx['d2']
+
+        d1 = self.options.getReal('d1', default=d1)
+        d2 = self.options.getReal('d2', default=d2)
+
+        # complex and real valued function spaces
+        W = v.function_space()
+        V = W.sub(0)
+
+        bcs = tuple((cb
+                     for bc in self.bcs
+                     for cb in cpx.DirichletBC(W, V, bc, 0*bc.function_arg)))
+
+        M = cpx.BilinearForm(W, d1, self.form_mass)
+        K = cpx.derivative(d2, partial(self.form_function, t=self.tref), self.uref)
+
+        a = M + K
+
+        return (a, bcs)

--- a/asQ/preconditioners/circulantpc.py
+++ b/asQ/preconditioners/circulantpc.py
@@ -76,12 +76,11 @@ class CirculantPC(AllAtOnceBlockPCBase):
     If the AllAtOnceSolver's appctx contains a 'block_appctx' dictionary, this is
     added to the appctx of each block solver.  The appctx of each block solver also
     contains the following:
-        'blockid': index of the block.
         'd1': circulant eigenvalue of the mass matrix.
         'd2': circulant eigenvalue of the stiffness matrix.
         'cpx': complex-proxy module implementation set with 'diagfft_complex_proxy'.
-        'u0': state around which the blocks are linearised.
-        't0': time at which the blocks are linearised.
+        'uref': state around which the blocks are linearised.
+        'tref': time at which the blocks are linearised.
         'bcs': block boundary conditions.
         'form_mass': function used to build the block mass matrix.
         'form_function': function used to build the block stiffness matrix.
@@ -227,12 +226,11 @@ class CirculantPC(AllAtOnceBlockPCBase):
 
             # pass parameters into PC:
             appctx_h = {
-                "blockid": i,
                 "d1": d1,
                 "d2": d2,
                 "cpx": cpx,
-                "u0": self.u0,
-                "t0": self.t_average,
+                "uref": self.u0,
+                "tref": self.t_average,
                 "bcs": self.block_bcs,
                 "form_mass": self.form_mass,
                 "form_function": self.form_function,

--- a/asQ/preconditioners/jacobipc.py
+++ b/asQ/preconditioners/jacobipc.py
@@ -112,11 +112,10 @@ class JacobiPC(AllAtOnceBlockPCBase):
 
             # pass parameters into PC:
             appctx_h = {
-                "blockid": i,
                 "dt": self.dt,
                 "theta": self.theta,
-                "t0": t0,
-                "u0": u0,
+                "tref": t0,
+                "uref": u0,
                 "bcs": self.block_bcs,
                 "form_mass": self.form_mass,
                 "form_function": self.form_function,

--- a/examples/complex_proxy/advection.py
+++ b/examples/complex_proxy/advection.py
@@ -123,12 +123,10 @@ sparams = {
         'converged_reason': None,
         'rtol': rtol,
     },
-    'ksp_type': 'gmres',
+    'ksp_type': 'preonly',
     'pc_type': 'python',
-    'pc_python_type': 'asQ.AuxiliaryBlockPC',
-    'aux': {
-        'pc_type': 'ilu'
-    }
+    'pc_python_type': 'asQ.AuxiliaryComplexBlockPC',
+    'aux': lu_pc
 }
 
 # All of these are given to the block solver by the diagpc
@@ -139,8 +137,8 @@ sparams = {
 
 appctx = {
     'cpx': cpx,
-    'u0': w,
-    't0': None,
+    'uref': w,
+    'tref': None,
     'd1': D1pc,
     'd2': D2pc,
     'bcs': [],

--- a/examples/complex_proxy/heat.py
+++ b/examples/complex_proxy/heat.py
@@ -41,20 +41,11 @@ sparams = {
     'pc_type': 'python',
     'pc_python_type': 'asQ.AuxiliaryComplexBlockPC',
     'aux': {
-        'pc_type': 'ilu',
+        'pc_type': 'lu',
         'd1r': d1.real,
         'd1i': d1.imag,
     }
 }
-
-# sparams = {
-#     'ksp': {
-#         'monitor': None,
-#         'converged_rate': None,
-#     },
-#     'ksp_type': 'preonly',
-#     'pc_type': 'ilu',
-# }
 
 appctx = {
     'cpx': cpx,

--- a/examples/complex_proxy/heat.py
+++ b/examples/complex_proxy/heat.py
@@ -1,0 +1,73 @@
+import firedrake as fd
+from asQ.complex_proxy import vector as cpx
+
+import numpy as np
+
+mesh = fd.UnitSquareMesh(4, 4)
+
+V = fd.FunctionSpace(mesh, "CG", 1)
+W = cpx.FunctionSpace(V)
+
+
+def form_mass(u, v):
+    return u*v*fd.dx
+
+
+def form_function(u, v, t=None):
+    return fd.inner(fd.grad(u), fd.grad(v))*fd.dx
+
+
+d1 = 1.5 + 0.4j
+d2 = 0.3 - 0.2j
+
+u = fd.Function(W)
+
+M = cpx.BilinearForm(W, d1, form_mass)
+K = cpx.derivative(d2, form_function, u)
+
+A = M + K
+
+L = fd.Cofunction(W.dual())
+np.random.seed(12345)
+for dat in L.dat:
+    dat.data[:] = np.random.rand(*(dat.data.shape))
+
+sparams = {
+    'ksp': {
+        'monitor': None,
+        'converged_rate': None,
+    },
+    'ksp_type': 'preonly',
+    'pc_type': 'python',
+    'pc_python_type': 'asQ.AuxiliaryComplexBlockPC',
+    'aux': {
+        'pc_type': 'ilu',
+        'd1r': d1.real,
+        'd1i': d1.imag,
+    }
+}
+
+# sparams = {
+#     'ksp': {
+#         'monitor': None,
+#         'converged_rate': None,
+#     },
+#     'ksp_type': 'preonly',
+#     'pc_type': 'ilu',
+# }
+
+appctx = {
+    'cpx': cpx,
+    'uref': u,
+    'tref': None,
+    'd1': d1,
+    'd2': d2,
+    'bcs': [],
+    'form_mass': form_mass,
+    'form_function': form_function
+}
+
+problem = fd.LinearVariationalProblem(A, L, u)
+solver = fd.LinearVariationalSolver(problem, appctx=appctx,
+                                    solver_parameters=sparams)
+solver.solve()

--- a/examples/heat/heat_variable_diffusion.py
+++ b/examples/heat/heat_variable_diffusion.py
@@ -49,9 +49,9 @@ lu_parameters = {
 }
 
 aux_parameters = {
-    'ksp_type': 'richardson',
+    'ksp_type': 'gmres',
     'pc_type': 'python',
-    'pc_python_type': 'asQ.AuxiliaryBlockPC',
+    'pc_python_type': 'asQ.AuxiliaryComplexBlockPC',
     'aux': {
         'pc_type': 'ilu'
     }
@@ -68,15 +68,16 @@ solver_parameters = {
     'snes_type': 'ksponly',
     'ksp': {
         'monitor': None,
-        'converged_reason': None,
+        'converged_rate': None,
         'rtol': 1e-8,
     },
     'mat_type': 'matfree',
-    'ksp_type': 'gmres',
+    'ksp_type': 'richardson',
+    'ksp_norm_type': 'unpreconditioned',
     'pc_type': 'python',
     'pc_python_type': 'asQ.CirculantPC',
-    'diagfft_alpha': 1e-3,
-    'diagfft_block': block_parameters
+    'circulant_alpha': 1e-3,
+    'circulant_block': block_parameters
 }
 
 appctx = {'block_appctx': block_appctx}

--- a/tests/preconditioners/test_auxiliarypc.py
+++ b/tests/preconditioners/test_auxiliarypc.py
@@ -1,0 +1,94 @@
+import firedrake as fd
+import numpy as np
+import pytest
+
+
+def create_complex_solver(cpx, mesh, V, W, bcs, sparams):
+    def form_mass(u, v):
+        return u*v*fd.dx
+
+    def form_function(u, v, t=None):
+        return fd.inner(fd.grad(u), fd.grad(v))*fd.dx
+
+    d1 = 1.5 + 0.4j
+    d2 = 0.3 - 0.2j
+
+    u = fd.Function(W)
+
+    cpx_bcs = tuple((cb for bc in bcs
+                     for cb in cpx.DirichletBC(W, V, bc, 0*bc.function_arg)))
+
+    M = cpx.BilinearForm(W, d1, form_mass)
+    K = cpx.derivative(d2, form_function, u)
+
+    A = M + K
+
+    L = fd.Cofunction(W.dual())
+    np.random.seed(12345)
+    for dat in L.dat:
+        dat.data[:] = np.random.rand(*(dat.data.shape))
+
+    appctx = {
+        'cpx': cpx,
+        'uref': u,
+        'tref': None,
+        'd1': d1,
+        'd2': d2,
+        'bcs': cpx_bcs,
+        'form_mass': form_mass,
+        'form_function': form_function
+    }
+
+    problem = fd.LinearVariationalProblem(A, L, u, bcs=cpx_bcs)
+    solver = fd.LinearVariationalSolver(problem, appctx=appctx,
+                                        solver_parameters=sparams)
+    return solver, u
+
+
+bcopts = ['none', 'dirichlet']
+cpxopts = ['cpx_vector', 'cpx_mixed']
+
+
+@pytest.mark.parametrize("bcopt", bcopts)
+@pytest.mark.parametrize("cpxopt", cpxopts)
+def test_complex_blockpc(bcopt, cpxopt):
+    if cpxopt == 'cpx_vector':
+        from asQ.complex_proxy import vector as cpx
+    elif cpxopt == 'cpx_mixed':
+        from asQ.complex_proxy import mixed as cpx
+    else:
+        assert False and "complex_proxy type not recognised"
+
+    mesh = fd.UnitSquareMesh(4, 4)
+
+    V = fd.FunctionSpace(mesh, "CG", 1)
+    W = cpx.FunctionSpace(V)
+
+    if bcopt == 'none':
+        bcs = []
+    elif bcopt == 'dirichlet':
+        bcs = [fd.DirichletBC(V, 0, sub_domain=1)]
+    else:
+        assert False and "boundary condition option not recognised"
+
+    pc_type = 'ilu'
+
+    aux_sparams = {
+        'ksp_type': 'preonly',
+        'pc_type': 'python',
+        'pc_python_type': 'asQ.AuxiliaryComplexBlockPC',
+        'aux_pc_type': pc_type
+    }
+
+    direct_sparams = {
+        'ksp_type': 'preonly',
+        'pc_type': pc_type,
+    }
+
+    direct_solver, udirect = create_complex_solver(cpx, mesh, V, W, bcs, direct_sparams)
+    aux_solver, uaux = create_complex_solver(cpx, mesh, V, W, bcs, aux_sparams)
+
+    direct_solver.solve()
+    aux_solver.solve()
+
+    assert fd.errornorm(udirect, uaux) < 1e-12


### PR DESCRIPTION
Pulling out the auxiliary operator PC for a real-valued block from #152 and implementing it with the auxiliary operator for the complex blocks already in asQ.

Todo:

- [x] asQ.preconditioners file for auxiliary block pcs
- [x] test for complex block pc
- [x] test for real block pc
- [x] tidy up example script for aux pcs (remove commented code)
- [x] update other scripts/tests/pcs with new pc names and appctx keys