### PR TITLE
Only rebuild the CirculantPC blocks when the reference state has changed

### DIFF
--- a/asQ/preconditioners/circulantpc.py
+++ b/asQ/preconditioners/circulantpc.py
@@ -256,7 +256,8 @@ class CirculantPC(AllAtOnceBlockPCBase):
                     break
 
             block_problem = fd.LinearVariationalProblem(A, L, self.block_sol,
-                                                        bcs=self.block_bcs)
+                                                        bcs=self.block_bcs,
+                                                        constant_jacobian=True)
             block_solver = fd.LinearVariationalSolver(block_problem,
                                                       appctx=appctx_h,
                                                       options_prefix=block_prefix)
@@ -314,6 +315,9 @@ class CirculantPC(AllAtOnceBlockPCBase):
 
         cpx.set_real(self.u0, ustate)
         cpx.set_imag(self.u0, ustate)
+
+        for block in self.block_solvers:
+            block.invalidate_jacobian()
         return
 
     @profiler()

--- a/asQ/preconditioners/jacobipc.py
+++ b/asQ/preconditioners/jacobipc.py
@@ -138,7 +138,8 @@ class JacobiPC(AllAtOnceBlockPCBase):
             # The block rhs/solution are the timestep i of the
             # input/output AllAtOnceCofunction/Function
             block_problem = fd.LinearVariationalProblem(A, self._x[i], self._y[i],
-                                                        bcs=self.block_bcs)
+                                                        bcs=self.block_bcs,
+                                                        constant_jacobian=True)
             block_solver = fd.LinearVariationalSolver(block_problem,
                                                       appctx=appctx_h,
                                                       options_prefix=block_prefix)
@@ -169,7 +170,7 @@ class JacobiPC(AllAtOnceBlockPCBase):
             st.assign(ft)
 
         if jacobian_state == 'linear':
-            pass
+            return
 
         elif jacobian_state == 'current':
             state_func.assign(aaofunc)
@@ -198,6 +199,9 @@ class JacobiPC(AllAtOnceBlockPCBase):
 
         elif jacobian_state == 'user':
             pass
+
+        for block in self.block_solvers:
+            block.invalidate_jacobian()
 
         return
 


### PR DESCRIPTION
The blocks of the circulant or jacobi preconditioners only need to be rebuilt when the reference state is updated. However by default, Firedrake will force the Jacobian and preconditioner to be rebuilt at every `LinearVariationalSolver.solve` call.

We can prevent this by setting `constant_jacobian=True` and explicitly telling the blocks when they need to rebuild.
