### PR TITLE
Upstream fixes

### DIFF
--- a/asQ/common.py
+++ b/asQ/common.py
@@ -26,31 +26,23 @@ def get_option_from_list(prefix, option_name, option_list,
     return option
 
 
-class MissingOption:
-    pass
-
-
-missing_option = MissingOption()
-
-
 def get_deprecated_option(getOption, prefix, deprecated_prefix,
                           option_name, default=None):
     deprecated_name = deprecated_prefix + option_name
     option_name = prefix + option_name
 
     deprecated_option = getOption(deprecated_name,
-                                  default=missing_option)
+                                  default=default)
     option = getOption(option_name,
-                       default=missing_option)
+                       default=default)
 
-    if deprecated_option is not missing_option:
+    if deprecated_option != default:
         msg = f"Prefix {deprecated_prefix} is deprecated and will be removed in the future. Use {prefix} instead."
         warn(msg)
-
-        if option is not missing_option:
+        if option != default:
             msg = f"{deprecated_name} ignored in favour of {option_name}"
             warn(msg)
+        else:
+            option = deprecated_option
 
-    for opt in (option, deprecated_option, default):
-        if opt is not missing_option:
-            return opt
+    return option

--- a/asQ/preconditioners/base.py
+++ b/asQ/preconditioners/base.py
@@ -166,18 +166,18 @@ class AllAtOnceBlockPCBase(AllAtOncePCBase):
         # Problem parameter options
         if self.deprecated_prefix is None:
             self.dt = PETSc.Options().getReal(
-                f"{self.full_prefix}dt", default=self.aaoform.dt)
+                f"{self.full_prefix}dt", default=self.aaoform.dt.values()[0])
 
             self.theta = PETSc.Options().getReal(
-                f"{self.full_prefix}theta", default=self.aaoform.theta)
+                f"{self.full_prefix}theta", default=self.aaoform.theta.values()[0])
         else:
             self.dt = get_deprecated_option(
                 PETSc.Options().getReal, self.full_prefix,
-                self.deprecated_prefix, "dt", default=self.aaoform.dt)
+                self.deprecated_prefix, "dt", default=self.aaoform.dt.values()[0])
 
             self.theta = get_deprecated_option(
                 PETSc.Options().getReal, self.full_prefix,
-                self.deprecated_prefix, "theta", default=self.aaoform.theta)
+                self.deprecated_prefix, "theta", default=self.aaoform.theta.values()[0])
 
         self.time = tuple(fd.Constant(0) for _ in range(self.nlocal_timesteps))
 

--- a/case_studies/shallow_water/blockpc/swe_cpx.py
+++ b/case_studies/shallow_water/blockpc/swe_cpx.py
@@ -430,7 +430,7 @@ for i in range(neigs):
     solver.invalidate_jacobian()
 
     if verbosity > 0:
-        PETSc.Sys.Print(f"Eigenvalues {str(k).rjust(3)}:\n    d1 = {np.round(d1,4)}, d2 = {np.round(d2,4)}, dhat = {np.round(dhat,4)}")
+        PETSc.Sys.Print(f"Eigenvalues {str(k).rjust(3)}:\n    d1 = {np.round(d1, 4)}, d2 = {np.round(d2, 4)}, dhat = {np.round(dhat, 4)}")
 
     np.random.seed(args.seed)
     for j in range(args.nrhs):

--- a/utils/hybridisation.py
+++ b/utils/hybridisation.py
@@ -86,7 +86,9 @@ class BrokenHDivProjector:
                   "dst": (dst, INC)})
 
 
-def _break_function_space(V, appctx):
+def _break_function_space(V, appctx=None):
+    if appctx is None:
+        appctx = {}
     cpx = appctx.get('cpx', None)
     mesh = V.mesh()
 


### PR DESCRIPTION
1. flake8 complained about a missing space after comma that was previously fine.
2. `PETSc.Options.get*` methods now require the default argument to be the correct type.
3. No longer require an appctx for calling `_break_function_space` without passing an appctx dictionary (this one wasn't causing failures, it's just removing an unnecessary restriction).