### PR TITLE
Revert to using firedrake-vanilla docker container

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: self-hosted
     # The docker container to use.
     container:
-      image: firedrakeproject/firedrake:latest
+      image: firedrakeproject/firedrake-vanilla:latest
     env:
       ASQ_CI_TESTS: 1
       OMP_NUM_THREADS: 1
@@ -46,6 +46,10 @@ jobs:
           . /home/firedrake/firedrake/bin/activate
           python -m pip install pytest-timeout
           python -m pip install pytest-cov
+      - name: Install
+        run: |
+          . /home/firedrake/firedrake/bin/activate
+          python -m pip install -e .
       - name: Lint
         run: |
           . /home/firedrake/firedrake/bin/activate


### PR DESCRIPTION
Once asQ could be installed as part of the `firedrake-install` script, I updated the asQ CI to use the Firedrake docker container with asQ installed in #180.

This was a mistake, because that docker container installs the master branch of asQ, so since that change the CI on each PR has actually been running with the master branch not the PR branch. Worse, it also hasn't been correct when running the CI on master once each PR has merged, because the docker container has the version of master from whenever the container was built, not the version of when we run it.

This PR reverts this change, so we're now back to using the vanilla firedrake docker in the CI, and installing the current branch of asQ before running the tests.