### PR TITLE
Time dependent `DirichletBC`

### DIFF
--- a/asQ/allatonce/form.py
+++ b/asQ/allatonce/form.py
@@ -100,11 +100,11 @@ class AllAtOnceForm(TimePartitionMixin):
 
         for bc in field_bcs:
 
-            if isinstance(bc, Callable):
+            if callable(bc):
                 for step in range(aaofunc.nlocal_timesteps):
                     Vs = [aaofunc.function_space.sub(i)
                           for i in aaofunc._component_indices(step)]
-                    us = aaofunc[step]
+                    us = aaofunc[step].subfunctions
                     t = self.time[step]
                     bcs_step = bc(*Vs, *us, t)
                     bcs_all.extend(bcs_step)
@@ -156,7 +156,7 @@ class AllAtOnceForm(TimePartitionMixin):
 
         # Set the current state
         if func is not None:
-            self.aaofunc.assign(func, update_halos=False)
+            self.aaofunc.assign(func, update_halos=False, blocking=True)
 
         # Assembly stage
         # The residual on the DirichletBC nodes is set to zero,

--- a/asQ/allatonce/jacobian.py
+++ b/asQ/allatonce/jacobian.py
@@ -141,7 +141,7 @@ class AllAtOnceJacobian(TimePartitionMixin):
         :arg X: a PETSc Vec to apply the action on.
         :arg Y: a PETSc Vec for the result.
         """
-        # we could use nonblocking here and overlap comms with assembling form
+        # Delay updating the halos until after we enforce the bcs
         self.x.assign(X, update_halos=True, blocking=True)
 
         # We use the same strategy as the implicit matrix context in firedrake
@@ -159,6 +159,7 @@ class AllAtOnceJacobian(TimePartitionMixin):
         # Zero the boundary nodes on the input so that A_ib = A_01 = 0
         for bc in self.bcs:
             bc.zero(self.x.function)
+        self.x.update_time_halos()
 
         # assembly stage
         fd.assemble(self.action, bcs=self.bcs,
@@ -166,8 +167,6 @@ class AllAtOnceJacobian(TimePartitionMixin):
 
         if self._useprev:
             # repeat for the halo part of the matrix action
-            for bc in self.field_bcs:
-                bc.zero(self.x.uprev)
             fd.assemble(self.action_prev, bcs=self.bcs,
                         tensor=self.Fprev)
             self.F.cofunction += self.Fprev

--- a/tests/integration/test_paradiag.py
+++ b/tests/integration/test_paradiag.py
@@ -114,7 +114,6 @@ def test_time_dependent_bcs():
         distribution_parameters={'partitioner_type': 'simple'})
 
     x, y = fd.SpatialCoordinate(mesh)
-    n = fd.FacetNormal(mesh)
     V = fd.FunctionSpace(mesh, "CG", degree)
 
     def uexact(t):
@@ -124,10 +123,7 @@ def test_time_dependent_bcs():
         return phi*q*fd.dx
 
     def form_function(q, phi, t):
-        return (fd.inner(fd.grad(q), fd.grad(phi))*fd.dx
-                - fd.inner(phi, fd.inner(fd.grad(q), n))*fd.ds
-                - fd.inner(q-uexact(t), fd.inner(fd.grad(phi), n))*fd.ds
-                + 20*nx*fd.inner(q-uexact(t), phi)*fd.ds)
+        return fd.inner(fd.grad(q), fd.grad(phi))*fd.dx
 
     def form_bcs(V, q, t):
         return [fd.DirichletBC(V, uexact(t), "on_boundary")]
@@ -138,21 +134,22 @@ def test_time_dependent_bcs():
         'ksp_rtol': 1e-8,
         'mat_type': 'matfree',
         'ksp_type': 'gmres',
-        'pc_type': 'python',
-        'pc_python_type': 'asQ.CirculantPC',
-        'circulant_block': {
-            'ksp_type': 'preonly',
-            'pc_type': 'lu',
-            'pc_factor_mat_solver_type': 'mumps'
-        },
+        'pc_type': 'none',
+        # 'pc_type': 'python',
+        # 'pc_python_type': 'asQ.CirculantPC',
+        # 'circulant_block': {
+        #     'ksp_type': 'preonly',
+        #     'pc_type': 'lu',
+        #     'pc_factor_mat_solver_type': 'mumps'
+        # },
     }
 
     w0 = fd.Function(V).interpolate(uexact(0))
 
     pdg = asQ.Paradiag(ensemble=ensemble,
                        form_function=form_function,
-                       form_mass=form_mass, ics=w0,
-                       dt=dt, theta=0.5,
+                       form_mass=form_mass, bcs=[form_bcs],
+                       dt=dt, theta=0.5, ics=w0,
                        time_partition=time_partition,
                        solver_parameters=solver_parameters_diag)
     pdg.solve()


### PR DESCRIPTION
Allow boundary conditions for an `AllAtOnceForm` to depend on the time and solution at each timestep.