### PR TITLE
Fixes for compatibility with firedrake release 2025.4.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: [self-hosted, Linux]
     # Use the firedrake container without asQ installed - we want to run the repo version.
     container:
-      image: firedrakeproject/firedrake-vanilla-default:2025.4.1
+      image: firedrakeproject/firedrake-vanilla-default:latest
     env:
       # Sometimes we want to determine if tests are running on CI
       ASQ_CI_TESTS: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Lint and test
+name: Install and test asQ
 
 on:
   # Run on pushes to master
@@ -7,59 +7,158 @@ on:
       - master
   # And all pull requests
   pull_request:
+  schedule:
+    # Scheduled run over at 0217 UTC Sunday to detect any upstream breaks.
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '17 2 * * 0'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 concurrency:
   # Cancels jobs running if new commits are pushed
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: >
+    ${{ github.workflow }}-
+    ${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
     name: "Build and test asQ"
-    # The type of runner that the job will run on
-    # runs-on: ubuntu-latest
+    # Use Firedrake's Linux runners
     runs-on: [self-hosted, Linux]
-    # The docker container to use.
+    # Use the firedrake container without asQ installed - we want to run the repo version.
     container:
-      image: firedrakeproject/firedrake-vanilla:latest
+      image: firedrakeproject/firedrake-vanilla-default:2025.4.1
     env:
+      # Sometimes we want to determine if tests are running on CI
       ASQ_CI_TESTS: 1
-      OMP_NUM_THREADS: 1
-      OPENBLAS_NUM_THREADS: 1
+      # Tell pyop2 to complain if SPMD assumptions are broken
       PYOP2_SPMD_STRICT: 1
-    # Steps represent a sequence of tasks that will be executed as
-    # part of the jobs
+      # Make sure tests with >8 processes are not silently skipped
+      PYTEST_MPI_MAX_NPROCS: 8
+      # Common arguments for pytest. TODO: Is pytest coverage possible firedrake-run-split-tests?
+      PYTEST_ARGS: --durations=30 --timeout=500 --timeout-method=thread -o faulthandler_timeout=600 --verbose asQ-repo/tests/
+      # venv activation script
+      ACTIVATE: venv-asQ/bin/activate
     steps:
-      - name: Fix permissions
-        # Firedrake's Dockerfile sets USER to firedrake instead of
-        # using the default user, so we need to update file
-        # permissions for this image to work on GH Actions.
-        # See https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#docker-container-filesystem
-        # (copied from https://help.github.com/en/actions/migrating-to-github-actions/migrating-from-circleci-to-github-actions)
+      - name: Fix HOME
+        # For unknown reasons GitHub actions overwrite HOME to /github/home
+        # which will break everything unless fixed
+        # (https://github.com/actions/runner/issues/863)
+        run: echo "HOME=/home/firedrake" >> "$GITHUB_ENV"
+
+      - name: Pre-cleanup
+      # TODO: Why do we need to do this?
         run: |
-          sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
-      - uses: actions/checkout@v2
-      - name: Install test dependencies
+          : # Wipe everything away in the current directory
+          find . -delete
+          firedrake-clean
+
+      - uses: actions/checkout@v4
+        with:
+          # Download asQ into a subdirectory not called 'asQ' to make sure
+          # that the package installs correctly. Otherwise 'import asQ' may
+          # work even if the installation failed because it is a subdirectory.
+          path: asQ-repo
+
+      - name: Create virtual environment
+        # pass '--system-site-packages' so Firedrake can be found
+        run: python3 -m venv --system-site-packages venv-asQ
+
+      - name: Install asQ
+        id: install
         run: |
-          . /home/firedrake/firedrake/bin/activate
-          python -m pip install pytest-timeout
-          python -m pip install pytest-cov
-      - name: Install
-        run: |
-          . /home/firedrake/firedrake/bin/activate
-          python -m pip install -e .
+          . $ACTIVATE
+          python --version
+          pip --version
+          pip install ./asQ-repo
+          python -m pip install flake8
+          pip list
+          python -m pytest --version
+
       - name: Lint
         run: |
-          . /home/firedrake/firedrake/bin/activate
-          flake8 --version
+          . $ACTIVATE
+          cd ./asQ-repo
           flake8 .
-      - name: Test
+
+      - name: Run tests (nprocs = 1)
+        # Run even if earlier tests failed
+        if: success() || steps.install.conclusion == 'success'
         run: |
-          . /home/firedrake/firedrake/bin/activate
-          python --version
-          python -m pytest --version
-          firedrake-status
-          python -m pytest -v -n 6 --durations=40 --timeout=600 --cov=asQ --cov-report=term tests/
+          . $ACTIVATE
+          : # Use pytest-xdist here so we can have a single collated output (not possible
+          : # for parallel tests)
+          firedrake-run-split-tests 1 1 "$PYTEST_ARGS"
+        timeout-minutes: 20
+
+      - name: Run tests (nprocs = 2)
+        # Run even if earlier tests failed
+        if: success() || steps.install.conclusion == 'success'
+        run: |
+          . $ACTIVATE
+          firedrake-run-split-tests 2 1 "$PYTEST_ARGS"
+        timeout-minutes: 20
+
+      - name: Run tests (nprocs = 3)
+        # Run even if earlier tests failed
+        if: success() || steps.install.conclusion == 'success'
+        run: |
+          . $ACTIVATE
+          firedrake-run-split-tests 3 1 "$PYTEST_ARGS"
+        timeout-minutes: 20
+
+      - name: Run tests (nprocs = 4)
+        # Run even if earlier tests failed
+        if: success() || steps.install.conclusion == 'success'
+        run: |
+          . $ACTIVATE
+          firedrake-run-split-tests 4 1 "$PYTEST_ARGS"
+        timeout-minutes: 20
+
+      - name: Run tests (nprocs = 5)
+        # Run even if earlier tests failed
+        if: success() || steps.install.conclusion == 'success'
+        run: |
+          . $ACTIVATE
+          firedrake-run-split-tests 5 1 "$PYTEST_ARGS"
+        timeout-minutes: 20
+
+      - name: Run tests (nprocs = 6)
+        # Run even if earlier tests failed
+        if: success() || steps.install.conclusion == 'success'
+        run: |
+          . $ACTIVATE
+          firedrake-run-split-tests 6 1 "$PYTEST_ARGS"
+        timeout-minutes: 20
+
+      - name: Run tests (nprocs = 7)
+        # Run even if earlier tests failed
+        if: success() || steps.install.conclusion == 'success'
+        run: |
+          . $ACTIVATE
+          firedrake-run-split-tests 7 1 "$PYTEST_ARGS"
+        timeout-minutes: 20
+
+      - name: Run tests (nprocs = 8)
+        # Run even if earlier tests failed
+        if: success() || steps.install.conclusion == 'success'
+        run: |
+          . $ACTIVATE
+          firedrake-run-split-tests 8 1 "$PYTEST_ARGS"
+        timeout-minutes: 20
+
+      - name: Upload pytest log files
+        uses: actions/upload-artifact@v4
+        if: success() || steps.install.conclusion == 'success'
+        with:
+          name: pytest-logs
+          path: pytest_*.log
+          retention-days: 7
+
+      - name: Post-cleanup
+        if: always()
+        run: |
+          find . -delete
+          firedrake-clean

--- a/asQ/allatonce/function.py
+++ b/asQ/allatonce/function.py
@@ -67,7 +67,7 @@ class AllAtOnceFunctionBase(TimePartitionMixin):
         self.function_space = reduce(mul, (self.field_function_space
                                            for _ in range(self.nlocal_timesteps)))
 
-        self.ncomponents = len(self.field_function_space.subfunctions)
+        self.ncomponents = len(self.field_function_space.subspaces)
 
         # this will be renamed either self.function or self.cofunction
         self._fbuf = fd.Function(self.function_space)

--- a/asQ/complex_proxy/vector_impl.py
+++ b/asQ/complex_proxy/vector_impl.py
@@ -96,7 +96,7 @@ def split(u, i):
 
     us = fd.split(u)
 
-    ncomponents = len(u.function_space().subfunctions)
+    ncomponents = len(u.function_space().subspaces)
 
     if ncomponents == 1:
         return tuple((us[i],))

--- a/asQ/post.py
+++ b/asQ/post.py
@@ -37,7 +37,7 @@ def write_timesteps(pdg,
     # functions for writing to file
     functions = []
     for cpt in range(pdg.ncpts):
-        V = pdg.W.subfunctions[cpt]
+        V = pdg.W.subspaces[cpt]
         if len(function_names) != 0:
             functions.append(fd.Function(V, name=function_names[cpt]))
         else:
@@ -108,7 +108,7 @@ def write_timeseries(pdg,
     # functions for writing to file
     functions = []
     for cpt in range(pdg.ncpts):
-        V = pdg.W.subfunctions[cpt]
+        V = pdg.W.subspaces[cpt]
         if len(function_names) != 0:
             functions.append(fd.Function(V, name=function_names[cpt]))
         else:

--- a/asQ/preconditioners/base.py
+++ b/asQ/preconditioners/base.py
@@ -48,7 +48,7 @@ class AllAtOncePCBase(TimePartitionMixin):
             raise ValueError("Expecting PC type python")
 
         # grab aao objects off petsc mat python context
-        prefix = pc.getOptionsPrefix()
+        prefix = pc.getOptionsPrefix() or ""
         self.full_prefix = prefix + self.prefix
         if hasattr(self, "deprecated_prefix"):
             self.deprecated_prefix = prefix + self.deprecated_prefix

--- a/case_studies/compressible3D/mountain3D.py
+++ b/case_studies/compressible3D/mountain3D.py
@@ -101,7 +101,7 @@ mesh.coordinates.interpolate(xexpr)
 W, Vv = euler.function_space(mesh, horizontal_degree=args.degree,
                              vertical_degree=args.degree,
                              vertical_velocity_space=True)
-V1, V2, Vt = W.subfunctions  # velocity, density, temperature
+V1, V2, Vt = W.subspaces  # velocity, density, temperature
 
 PETSc.Sys.Print(f"DoFs: {W.dim()}")
 PETSc.Sys.Print(f"DoFs/core: {W.dim()/ensemble.comm.size}")

--- a/case_studies/compressible3D/mountain3D_comparison.py
+++ b/case_studies/compressible3D/mountain3D_comparison.py
@@ -94,7 +94,7 @@ mesh.coordinates.interpolate(xexpr)
 W, Vv = euler.function_space(mesh, horizontal_degree=args.degree,
                              vertical_degree=args.degree,
                              vertical_velocity_space=True)
-V1, V2, Vt = W.subfunctions  # velocity, density, temperature
+V1, V2, Vt = W.subspaces  # velocity, density, temperature
 
 PETSc.Sys.Print(f"DoFs: {W.dim()}")
 PETSc.Sys.Print(f"DoFs/core: {W.dim()/comm.size}")

--- a/case_studies/compressible3D/mountain3D_serial.py
+++ b/case_studies/compressible3D/mountain3D_serial.py
@@ -90,7 +90,7 @@ mesh.coordinates.interpolate(xexpr)
 W, Vv = euler.function_space(mesh, horizontal_degree=args.degree,
                              vertical_degree=args.degree,
                              vertical_velocity_space=True)
-V1, V2, Vt = W.subfunctions  # velocity, density, temperature
+V1, V2, Vt = W.subspaces  # velocity, density, temperature
 
 PETSc.Sys.Print(f"DoFs: {W.dim()}")
 PETSc.Sys.Print(f"DoFs/core: {W.dim()/comm.size}")

--- a/case_studies/moist_shallow_water/sw_moist.py
+++ b/case_studies/moist_shallow_water/sw_moist.py
@@ -67,7 +67,7 @@ x, y, z = fd.SpatialCoordinate(mesh)
 outward_normals = fd.CellNormal(mesh)
 
 Vdry = swe.default_function_space(mesh, degree=args.degree)
-V1, V2 = Vdry.subfunctions
+V1, V2 = Vdry.subspaces
 V0 = fd.FunctionSpace(mesh, "CG", args.degree+2)
 W = fd.MixedFunctionSpace((V1, V2, V2, V2, V2, V2))
 # velocity, depth, temperature, vapour, cloud, rain

--- a/case_studies/moist_shallow_water/sw_moist_serial.py
+++ b/case_studies/moist_shallow_water/sw_moist_serial.py
@@ -53,7 +53,7 @@ x, y, z = fd.SpatialCoordinate(mesh)
 outward_normals = fd.CellNormal(mesh)
 
 Vdry = swe.default_function_space(mesh, degree=args.degree)
-V1, V2 = Vdry.subfunctions
+V1, V2 = Vdry.subspaces
 V0 = fd.FunctionSpace(mesh, "CG", args.degree+2)
 W = fd.MixedFunctionSpace((V1, V2, V2, V2, V2, V2))
 # velocity, depth, temperature, vapour, cloud, rain

--- a/case_studies/shallow_water/blockpc/swe_cpx.py
+++ b/case_studies/shallow_water/blockpc/swe_cpx.py
@@ -28,7 +28,7 @@ class ApproxHybridPC(fd.PCBase):
         V = appctx['uref'].function_space()
 
         # input and output functions
-        _, Vh = V.subfunctions
+        _, Vh = V.subspaces
         self.xfstar = fd.Cofunction(Vh.dual())
         self.xf = fd.Function(Vh)  # result of riesz map of the above
 
@@ -102,7 +102,7 @@ def read_checkpoint(checkpoint_name, funcname, index, ref_level=0):
                                             coords_degree=1)
 
         V = fd.FunctionSpace(mesh_new, u.function_space().ufl_element())
-        Vu, Vh = V.subfunctions
+        Vu, Vh = V.subspaces
 
         unew = fd.Function(V)
         coriolis_new = fd.Function(Vh)

--- a/case_studies/shallow_water/checkpoints/galewsky_checkpoints.py
+++ b/case_studies/shallow_water/checkpoints/galewsky_checkpoints.py
@@ -62,7 +62,7 @@ dt = args.dt*units.hour
 
 # shallow water equation function spaces (velocity and depth)
 W = swe.default_function_space(mesh, degree=args.degree)
-Vu, Vh = W.subfunctions
+Vu, Vh = W.subspaces
 
 # parameters
 g = earth.Gravity

--- a/case_studies/shallow_water/williamson2.py
+++ b/case_studies/shallow_water/williamson2.py
@@ -62,7 +62,7 @@ x = fd.SpatialCoordinate(mesh)
 
 # Mixed function space for velocity and depth
 W = swe.default_function_space(mesh, degree=args.degree)
-V1, V2 = W.subfunctions[:]
+V1, V2 = W.subspaces[:]
 
 # initial conditions
 w0 = fd.Function(W)

--- a/case_studies/vertical_slice/slice_comparison.py
+++ b/case_studies/vertical_slice/slice_comparison.py
@@ -49,7 +49,7 @@ gas = euler.StandardAtmosphere(N=0.01)
 W, Vv = euler.function_space(mesh, horizontal_degree=args.degree,
                              vertical_degree=args.degree,
                              vertical_velocity_space=True)
-V1, V2, Vt = W.subfunctions  # velocity, density, temperature
+V1, V2, Vt = W.subspaces  # velocity, density, temperature
 
 PETSc.Sys.Print(f"DoFs: {W.dim()}")
 PETSc.Sys.Print(f"DoFs/core: {W.dim()/comm.size}")

--- a/case_studies/vertical_slice/slice_mountain.py
+++ b/case_studies/vertical_slice/slice_mountain.py
@@ -52,7 +52,7 @@ gas = euler.StandardAtmosphere(N=0.01)
 W, Vv = euler.function_space(mesh, horizontal_degree=args.degree,
                              vertical_degree=args.degree,
                              vertical_velocity_space=True)
-V1, V2, Vt = W.subfunctions  # velocity, density, temperature
+V1, V2, Vt = W.subspaces  # velocity, density, temperature
 
 PETSc.Sys.Print(f"DoFs: {W.dim()}")
 PETSc.Sys.Print(f"DoFs/core: {W.dim()/ensemble.comm.size}")

--- a/case_studies/vertical_slice/slice_mountain_serial.py
+++ b/case_studies/vertical_slice/slice_mountain_serial.py
@@ -43,7 +43,7 @@ n = fd.FacetNormal(mesh)
 W, Vv = euler.function_space(mesh, horizontal_degree=args.degree,
                              vertical_degree=args.degree,
                              vertical_velocity_space=True)
-V1, V2, Vt = W.subfunctions  # velocity, density, temperature
+V1, V2, Vt = W.subspaces  # velocity, density, temperature
 
 PETSc.Sys.Print(f"DoFs: {W.dim()}")
 PETSc.Sys.Print(f"DoFs/core: {W.dim()/comm.size}")

--- a/case_studies/vertical_slice/straka.py
+++ b/case_studies/vertical_slice/straka.py
@@ -49,7 +49,7 @@ gas = euler.StandardAtmosphere(N=0.01)
 W, Vv = euler.function_space(mesh, horizontal_degree=args.degree,
                              vertical_degree=args.degree,
                              vertical_velocity_space=True)
-V1, V2, Vt = W.subfunctions  # velocity, density, temperature
+V1, V2, Vt = W.subspaces  # velocity, density, temperature
 
 PETSc.Sys.Print(f"DoFs: {W.dim()}")
 PETSc.Sys.Print(f"DoFs/core: {W.dim()/mesh.comm.size}")

--- a/case_studies/vertical_slice/straka_comparison.py
+++ b/case_studies/vertical_slice/straka_comparison.py
@@ -44,7 +44,7 @@ gas = euler.StandardAtmosphere(N=0.01)
 W, Vv = euler.function_space(mesh, horizontal_degree=args.degree,
                              vertical_degree=args.degree,
                              vertical_velocity_space=True)
-V1, V2, Vt = W.subfunctions  # velocity, density, temperature
+V1, V2, Vt = W.subspaces  # velocity, density, temperature
 
 PETSc.Sys.Print(f"DoFs: {W.dim()}")
 PETSc.Sys.Print(f"DoFs/core: {W.dim()/comm.size}")

--- a/case_studies/vertical_slice/straka_serial.py
+++ b/case_studies/vertical_slice/straka_serial.py
@@ -36,7 +36,7 @@ gas = euler.StandardAtmosphere(N=0.01)
 W, Vv = euler.function_space(mesh, horizontal_degree=args.degree,
                              vertical_degree=args.degree,
                              vertical_velocity_space=True)
-V1, V2, Vt = W.subfunctions  # velocity, density, temperature
+V1, V2, Vt = W.subspaces  # velocity, density, temperature
 
 PETSc.Sys.Print(f"DoFs: {W.dim()}")
 PETSc.Sys.Print(f"DoFs/core: {W.dim()/mesh.comm.size}")

--- a/tests/complex_proxy/test_complex_mixed.py
+++ b/tests/complex_proxy/test_complex_mixed.py
@@ -119,15 +119,15 @@ def test_mixed_function_space(mesh, mixed_element):
     V = fd.FunctionSpace(mesh, mixed_element)
     W = cpx.FunctionSpace(V)
 
-    assert len(W.subfunctions) == 2*len(V.subfunctions), "The complex space should have twice the number of components as the real space"
+    assert len(W.subspaces) == 2*len(V.subspaces), "The complex space should have twice the number of components as the real space"
 
     for i in range(V.ufl_element().num_sub_elements):
         idx_real = 2*i+0
         idx_imag = 2*i+1
 
-        real_elem = W.subfunctions[idx_real].ufl_element()
-        imag_elem = W.subfunctions[idx_imag].ufl_element()
-        orig_elem = V.subfunctions[i].ufl_element()
+        real_elem = W.subspaces[idx_real].ufl_element()
+        imag_elem = W.subspaces[idx_imag].ufl_element()
+        orig_elem = V.subspaces[i].ufl_element()
 
         assert real_elem == orig_elem, "The complex function space should have the cpx Element corresponding to the cpx Element of the real space"
         assert imag_elem == orig_elem, "The complex function space should have the cpx Element corresponding to the cpx Element of the real space"

--- a/tests/complex_proxy/test_complex_vector.py
+++ b/tests/complex_proxy/test_complex_vector.py
@@ -127,9 +127,9 @@ def test_mixed_function_space(mesh, mixed_element):
     V = fd.FunctionSpace(mesh, mixed_element)
     W = cpx.FunctionSpace(V)
 
-    assert len(W.subfunctions) == len(V.subfunctions), "The complex space should have the same number of components as the real space"
+    assert len(W.subspaces) == len(V.subspaces), "The complex space should have the same number of components as the real space"
 
-    for wcpt, vcpt in zip(W.subfunctions, V.subfunctions):
+    for wcpt, vcpt in zip(W.subspaces, V.subspaces):
         assert wcpt == cpx.FunctionSpace(vcpt), "Each component of the complex space should be the complex space of the component of the real space"
 
 

--- a/utils/compressible_flow/compressible_flow.py
+++ b/utils/compressible_flow/compressible_flow.py
@@ -45,19 +45,19 @@ def function_space(mesh, horizontal_degree=1, vertical_degree=1,
 
 
 def velocity_function_space(mesh, horizontal_degree=1, vertical_degree=1):
-    return function_space(mesh, horizontal_degree, vertical_degree).subfunctions[0]
+    return function_space(mesh, horizontal_degree, vertical_degree).subspaces[0]
 
 
 def pressure_function_space(mesh, horizontal_degree=1, vertical_degree=1):
-    return function_space(mesh, horizontal_degree, vertical_degree).subfunctions[1]
+    return function_space(mesh, horizontal_degree, vertical_degree).subspaces[1]
 
 
 def density_function_space(mesh, horizontal_degree=1, vertical_degree=1):
-    return function_space(mesh, horizontal_degree, vertical_degree).subfunctions[1]
+    return function_space(mesh, horizontal_degree, vertical_degree).subspaces[1]
 
 
 def temperature_function_space(mesh, horizontal_degree=1, vertical_degree=1):
-    return function_space(mesh, horizontal_degree, vertical_degree).subfunctions[2]
+    return function_space(mesh, horizontal_degree, vertical_degree).subspaces[2]
 
 
 def hydrostatic_rho(Vv, V2, mesh, thetan, rhon, pi_boundary,

--- a/utils/hybridisation.py
+++ b/utils/hybridisation.py
@@ -103,7 +103,7 @@ def _break_function_space(V, appctx=None):
         raise ValueError(msg)
 
     # hybridisable space - broken HDiv and Trace
-    Vs = V.subfunctions
+    Vs = V.subspaces
 
     Vu = Vs[iu]
 
@@ -204,7 +204,7 @@ class HybridisedSCPC(fd.PCBase):
 
         # the trace bit
         n = fd.FacetNormal(self.mesh)
-        ncpts = len(V.subfunctions)
+        ncpts = len(V.subspaces)
 
         def form_trace(*args):
             trls = args[:ncpts+1]

--- a/utils/shallow_water/miniapp.py
+++ b/utils/shallow_water/miniapp.py
@@ -104,7 +104,11 @@ class ShallowWaterMiniApp(TimePartitionMixin):
         u0 = w0.subfunctions[self.velocity_index]
         h0 = w0.subfunctions[self.depth_index]
 
-        u0.project(velocity_expression(*x), quadrature_degree=6)
+        # limit the projection degree to 2*V.degree+2 in case we
+        # get a non-polynomial expression (e.g. Galewsky ics)
+        u0.project(
+            velocity_expression(*x),
+            form_compiler_parameters={"quadrature_degree": 6})
         h0.interpolate(depth_expression(*x))
 
         if reference_state:

--- a/utils/vertical_slice/mount_agnesi.py
+++ b/utils/vertical_slice/mount_agnesi.py
@@ -90,7 +90,7 @@ def Tsurf(hydrostatic=False):
 
 def initial_conditions(mesh, W, Vv, gas, hydrostatic=False):
     x, z = fd.SpatialCoordinate(mesh)
-    V2 = W.subfunctions[1]
+    V2 = W.subspaces[1]
     Un = fd.Function(W)
     up = fd.as_vector([fd.Constant(0.0), fd.Constant(1.0)])  # up direction
 

--- a/utils/vertical_slice/straka.py
+++ b/utils/vertical_slice/straka.py
@@ -32,7 +32,7 @@ def mesh(comm, ncolumns, nlayers,
 
 
 def initial_conditions(mesh, W, Vv, gas):
-    V1, V2, Vt = W.subfunctions
+    V1, V2, Vt = W.subspaces
     Un = fd.Function(W)
     x, z = fd.SpatialCoordinate(mesh)
 


### PR DESCRIPTION
This fixes errors and warnings so asQ works with the latest firedrake release.
Once this is merged we can make a tagged asQ release so we're then free to develop on asQ/master using firedrake/master.

1. Update the github workflow for the pip install and release changes.
2. Fix for petsc changing default return val for an empty prefix.
3. Warning fix for `FunctionSpace.subfunctions` -> `subspaces`.
4. Warning fix for passing `quadrature_degree` to `project`.