### PR TITLE
Updates for `firedrake-2026.4.0`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
       image: firedrakeproject/firedrake-vanilla-default:latest
     env:
       # Sometimes we want to determine if tests are running on CI
-      ASQ_CI_TESTS: 1
+      FIREDRAKE_CI: 1
       # Tell pyop2 to complain if SPMD assumptions are broken
       PYOP2_SPMD_STRICT: 1
       # Make sure tests with >8 processes are not silently skipped

--- a/asQ/complex_proxy/mixed_impl.py
+++ b/asQ/complex_proxy/mixed_impl.py
@@ -52,7 +52,7 @@ def FunctionSpace(V):
 
     :arg V: the real-valued FunctionSpace.
     """
-    return fd.FunctionSpace(V.mesh(), FiniteElement(V.ufl_element()))
+    return fd.FunctionSpace(V.mesh().unique(), FiniteElement(V.ufl_element()))
 
 
 def DirichletBC(W, V, bc, function_arg=None):

--- a/asQ/complex_proxy/vector_impl.py
+++ b/asQ/complex_proxy/vector_impl.py
@@ -61,7 +61,7 @@ def FunctionSpace(V):
 
     :arg V: the real-valued FunctionSpace.
     """
-    return fd.FunctionSpace(V.mesh(), FiniteElement(V.ufl_element()))
+    return fd.FunctionSpace(V.mesh().unique(), FiniteElement(V.ufl_element()))
 
 
 def DirichletBC(W, V, bc, function_arg=None):

--- a/tests/complex_proxy/test_complex_mixed.py
+++ b/tests/complex_proxy/test_complex_mixed.py
@@ -523,10 +523,7 @@ def test_mixed_linear_solve(mesh, bc_type):
     if bc_type == "nobc":
         bcs = []
     elif bc_type == "dirichletbc":
-        bcs = [
-            fd.DirichletBC(V.sub(1), 0, 3),
-            fd.DirichletBC(V.sub(1), 0, 4)
-        ]
+        bcs = [fd.DirichletBC(V.sub(0), 0, 1)]
     else:
         raise ValueError(f"Unrecognised boundary condition type: {bc_type}")
 

--- a/tests/complex_proxy/test_complex_mixed.py
+++ b/tests/complex_proxy/test_complex_mixed.py
@@ -119,6 +119,10 @@ def test_mixed_function_space(mesh, mixed_element):
     V = fd.FunctionSpace(mesh, mixed_element)
     W = cpx.FunctionSpace(V)
 
+    assert V.ufl_element() == mixed_element
+    assert W.ufl_element() == cpx.FiniteElement(mixed_element)
+    assert W.ufl_element().num_sub_elements == 2*V.ufl_element().num_sub_elements
+
     assert len(W.subspaces) == 2*len(V.subspaces), "The complex space should have twice the number of components as the real space"
 
     for i in range(V.ufl_element().num_sub_elements):

--- a/tests/complex_proxy/test_complex_vector.py
+++ b/tests/complex_proxy/test_complex_vector.py
@@ -519,10 +519,7 @@ def test_mixed_linear_solve(mesh, bc_type):
     if bc_type == "nobc":
         bcs = []
     elif bc_type == "dirichletbc":
-        bcs = [
-            fd.DirichletBC(V.sub(1), 0, 3),
-            fd.DirichletBC(V.sub(1), 0, 4)
-        ]
+        bcs = [fd.DirichletBC(V.sub(0), 0, 1)]
     else:
         raise ValueError(f"Unrecognised boundary condition type: {bc_type}")
 

--- a/tests/preconditioners/test_allatonce_pcs.py
+++ b/tests/preconditioners/test_allatonce_pcs.py
@@ -5,7 +5,7 @@ import pytest
 
 def make_paradiag(time_partition, parameters):
     ensemble = asQ.create_ensemble(time_partition)
-    mesh = fd.UnitSquareMesh(
+    mesh = fd.PeriodicUnitSquareMesh(
         nx=16, ny=16, comm=ensemble.comm,
         distribution_parameters={'partitioner_type': 'simple'})
 
@@ -13,13 +13,19 @@ def make_paradiag(time_partition, parameters):
 
     V = fd.FunctionSpace(mesh, "CG", 1)
     uinitial = fd.Function(V)
-    uinitial.project(fd.sin(x) + fd.cos(y))
+    uinitial.project(fd.sin(2*fd.pi*x) + fd.cos(2*fd.pi*y))
+
+    c = fd.as_vector([1.0, 0.5])
+    nu = fd.Constant(1/100)
 
     def form_mass(u, v):
         return u*v*fd.dx
 
     def form_function(u, v, t):
-        return fd.inner(fd.grad(u), fd.grad(v))*fd.dx
+        return (
+            + fd.inner(fd.dot(c, fd.grad(u)), v)*fd.dx
+            + fd.inner(nu*fd.grad(u), fd.grad(v))*fd.dx
+        )
 
     return asQ.Paradiag(
         ensemble=ensemble,
@@ -68,6 +74,8 @@ def test_circulantpc(alpha):
 
     solver_parameters = {
         'snes_type': 'ksponly',
+        'ksp_monitor': None,
+        'ksp_converged_rate': None,
         'mat_type': 'matfree',
         'ksp_type': 'richardson',
         'ksp_rtol': alpha**3,
@@ -75,9 +83,8 @@ def test_circulantpc(alpha):
         'pc_python_type': 'asQ.CirculantPC',
         'circulant_alpha': alpha,
         'circulant_block': {
-            'ksp_type': 'richardson',
-            'ksp_rtol': alpha**2,
-            'pc_type': 'ilu',
+            'ksp_type': 'preonly',
+            'pc_type': 'lu',
         },
     }
 

--- a/tests/test_paradiag.py
+++ b/tests/test_paradiag.py
@@ -191,6 +191,7 @@ def test_Nitsche_heat_timeseries():
         assert err/norm0 < tol, "Serial and parallel solutions should match to solver tolerance"
 
 
+@pytest.mark.xfail(reason="https://github.com/firedrakeproject/firedrake/issues/5045")
 @pytest.mark.parallel(nprocs=[1, 4])
 def test_galewsky_timeseries():
     from utils import units

--- a/tests/test_paradiag.py
+++ b/tests/test_paradiag.py
@@ -234,8 +234,10 @@ def test_galewsky_timeseries():
     u_initial = w_initial.subfunctions[0]
     h_initial = w_initial.subfunctions[1]
 
-    u_initial.project(galewsky.velocity_expression(*x))
-    h_initial.project(galewsky.depth_expression(*x))
+    fcp = {'max_quadrature_degree': 2*degree+2}
+
+    u_initial.project(galewsky.velocity_expression(*x), form_compiler_parameters=fcp)
+    h_initial.project(galewsky.depth_expression(*x), form_compiler_parameters=fcp)
 
     # shallow water equation forms
     def form_function(u, h, v, q, t):

--- a/utils/hybridisation.py
+++ b/utils/hybridisation.py
@@ -1,5 +1,6 @@
 import firedrake as fd
 from firedrake.parloops import par_loop, READ, INC
+from firedrake.exceptions import NonUniqueMeshSequenceError
 from math import prod
 from functools import partial
 
@@ -23,7 +24,11 @@ class BrokenHDivProjector:
             raise TypeError(f"V must be in HDiv not {sobolev_space}")
 
         # create the broken function space
-        self.mesh = V.mesh()
+        try:
+            self.mesh = V.mesh().unique()
+        except NonUniqueMeshSequenceError:
+            raise NotImplementedError(
+                "Not implemented for general mixed meshes")
         self.V = V
         if Vb is None:
             Vb = fd.FunctionSpace(self.mesh, fd.BrokenElement(V.ufl_element()))
@@ -62,7 +67,7 @@ class BrokenHDivProjector:
         ev, eb = self.V.ufl_element(), self.Vb.ufl_element()
         echeck = (ev, eb)
         mx, my = x.function_space().mesh(), y.function_space().mesh()
-        mcheck = self.V.mesh()
+        mcheck = self.mesh
 
         valid_mesh = (mx == mcheck) and (my == mcheck)
         valid_elements = (ex in echeck) and (ey in echeck) and (ex != ey)
@@ -90,7 +95,11 @@ def _break_function_space(V, appctx=None):
     if appctx is None:
         appctx = {}
     cpx = appctx.get('cpx', None)
-    mesh = V.mesh()
+    try:
+        mesh = V.mesh().unique()
+    except NonUniqueMeshSequenceError:
+        raise NotImplementedError(
+            "Not implemented for general mixed meshes")
 
     # find HDiv space
     iu = None
@@ -307,7 +316,11 @@ class HybridisedSCPC(fd.PCBase):
 
         self.uref = appctx.get('uref')
         self.V = self.uref.function_space()
-        self.mesh = self.V.mesh()
+        try:
+            self.mesh = self.V.mesh().unique()
+        except NonUniqueMeshSequenceError:
+            raise NotImplementedError(
+                "Not implemented for general mixed meshes")
 
         self.bcs = appctx['bcs']
         self.tref = appctx['tref']

--- a/utils/mg.py
+++ b/utils/mg.py
@@ -20,8 +20,8 @@ class ManifoldTransferManager(fd.TransferManager):
         self._transfer(fine, coarse, super().inject)
 
     def _transfer(self, f0, f1, transfer_op):
-        mesh0 = f0.function_space().mesh()
-        mesh1 = f1.function_space().mesh()
+        mesh0 = f0.function_space().mesh().unique()
+        mesh1 = f1.function_space().mesh().unique()
 
         # backup the original coordinates the first time we see a mesh
         self._register_mesh(mesh0)

--- a/utils/shallow_water/galewsky.py
+++ b/utils/shallow_water/galewsky.py
@@ -63,7 +63,10 @@ def velocity_expression(x, y, z):
 
 def velocity_function(x, y, z, V1, name="velocity"):
     v = fd.Function(V1, name=name)
-    return v.project(velocity_expression(x, y, z))
+    k = V1.ufl_element().degree()
+    return v.project(
+        velocity_expression(x, y, z),
+        form_compiler_parameters={'max_quadrature_degree': 2*k+2})
 
 
 def depth_integrand(theta):

--- a/utils/shallow_water/miniapp.py
+++ b/utils/shallow_water/miniapp.py
@@ -107,9 +107,10 @@ class ShallowWaterMiniApp(TimePartitionMixin):
 
         # limit the projection degree to 2*V.degree+2 in case we
         # get a non-polynomial expression (e.g. Galewsky ics)
+        k = V1.ufl_element().degree()
         u0.project(
             velocity_expression(*x),
-            form_compiler_parameters={"quadrature_degree": 6})
+            form_compiler_parameters={"max_quadrature_degree": 2*k+2})
         h0.interpolate(depth_expression(*x))
 
         if reference_state:


### PR DESCRIPTION
Main updates:

1. `MixedFunctionSpace.mesh()` -> `MixedFunctionSpace.mesh().unique()` to avoid handling a `MeshSequence`.
2. Use `max_quadrature_degree` in `form_compiler_parameter` rather than a fixed `quadrature_degree`.
3. `xfail` the test with multigrid + HDiv + immersed mesh until https://github.com/firedrakeproject/firedrake/issues/5045 is fixed.